### PR TITLE
flake: add shellHook in devShell to ensure clangd is wrapped

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
         devShells.default = nixd.overrideAttrs (old: {
           nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.clang-tools pkgs.gdb ];
           shellHook = ''
+            export PATH="${pkgs.clang-tools}/bin:$PATH"
             export NIX_SRC=${pkgs.nixUnstable.src}
             export NIX_DEBUG_INFO_DIRS=${pkgs.nixUnstable.debug}/lib/debug
           '';


### PR DESCRIPTION
`clangd` provided by llvmPackages is unwrapped, and do not respect env:

    $NIX_CFLAGS_COMPILE

However this is critical for clangd to find headers, so let's add this workaround.