### PR TITLE
nixd/eval: put this stuff in main thread

### DIFF
--- a/lib/nixd/src/EvalDraftStore.cpp
+++ b/lib/nixd/src/EvalDraftStore.cpp
@@ -85,7 +85,7 @@ void EvalDraftStore::withEvaluation(
     }
   };
 
-  boost::asio::post(Pool, std::move(Job));
+  Job();
 }
 
 } // namespace nixd


### PR DESCRIPTION
... This will dramatically affect our speed on responding requests.

However, we have to do this, because nix evaluation is NOT thread-safe.