### PR TITLE
flake: add nixd overlay (providing the `nixd` package)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,15 +6,19 @@
   };
 
   outputs = { nixpkgs, flake-parts, ... }@inputs: flake-parts.lib.mkFlake { inherit inputs; } {
+    imports = [
+      inputs.flake-parts.flakeModules.easyOverlay
+    ];
     perSystem = { config, self', inputs', pkgs, system, ... }:
       let
         nixd = pkgs.callPackage ./default.nix { };
       in
       {
-        packages = {
-          inherit nixd;
-          default = nixd;
+        packages.default = nixd;
+        overlayAttrs = {
+          inherit (config.packages) nixd;
         };
+        packages.nixd = nixd;
 
         devShells.default = nixd.overrideAttrs (old: {
           nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.clang-tools pkgs.gdb ];


### PR DESCRIPTION
add overlay support

```nix 
{
  description = "My configuration";

  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
    nixd.url = "github:nix-community/nixd";
  };

  outputs = { nixpkgs, nixd, ... }:
    {
      nixosConfigurations = {
        hostname = nixpkgs.lib.nixosSystem
          {
            system = "x86_64-linux";
            modules = [
              {
                nixpkgs.overlays = [ nixd.overlays.default ];
                environment.systemPackages = with pkgs;[
                  nixd
                ];
              }
            ];
          };
      };
    };
}
```


