### PR TITLE
nixd/nix: add nix extension `forceValueDepth` to `nix::EvalState`

### DIFF
--- a/lib/nixd/include/nixd/nix/EvalState.h
+++ b/lib/nixd/include/nixd/nix/EvalState.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <nix/eval.hh>
+
+// Our extension to nix::EvalState.
+namespace nix {
+/// Similar to nix forceValue, but allow a depth limit
+void forceValueDepth(EvalState &State, Value &v, int depth);
+} // namespace nix

--- a/lib/nixd/meson.build
+++ b/lib/nixd/meson.build
@@ -8,6 +8,7 @@ nixd_server_lib = library('nixd-lsp'
   , 'src/JSONSerialization.cpp'
   , 'src/ServerController.cpp'
   , 'src/ServerWorker.cpp'
+  , 'src/nix/EvalState.cpp'
   ]
 , include_directories: nixd_server_inc
 , dependencies: [ llvm

--- a/lib/nixd/src/nix/EvalState.cpp
+++ b/lib/nixd/src/nix/EvalState.cpp
@@ -1,0 +1,39 @@
+#include "nixd/nix/EvalState.h"
+
+namespace nix {
+
+void forceValueDepth(EvalState &State, Value &v, int depth) {
+  std::set<const Value *> seen;
+
+  std::function<void(Value & v, int Depth)> recurse;
+
+  recurse = [&](Value &v, int depth) {
+    if (depth == 0)
+      return;
+    if (!seen.insert(&v).second)
+      return;
+
+    State.forceValue(v, [&]() { return v.determinePos(noPos); });
+
+    if (v.type() == nAttrs) {
+      for (auto &i : *v.attrs)
+        try {
+          // If the value is a thunk, we're evaling. Otherwise no trace
+          // necessary.
+          recurse(*i.value, depth - 1);
+        } catch (Error &e) {
+          State.addErrorTrace(e, i.pos, "while evaluating the attribute '%1%'",
+                              State.symbols[i.name]);
+          throw;
+        }
+    }
+
+    else if (v.isList()) {
+      for (auto v2 : v.listItems())
+        recurse(*v2, depth - 1);
+    }
+  };
+
+  recurse(v, depth - 1);
+}
+} // namespace nix


### PR DESCRIPTION
This is a helper function (and could be upstreamed) that can specify a depth limit in `nix::EvalState::forceValue`, which allows our user to configure the installable with additional eval depth (and thus their structs in ExprAttrs will be evaluated.)