### PR TITLE
nixd/diagnostic: send evaluation diagnostic to client

### DIFF
--- a/lib/nixd/include/nixd/Server.h
+++ b/lib/nixd/include/nixd/Server.h
@@ -79,7 +79,7 @@ class Server : public lspserver::LSPServer {
 
   void removeDocument(lspserver::PathRef File) {
     DraftMgr.removeDraft(File);
-    updateWorkspaceVersion();
+    updateWorkspaceVersion(File);
   }
 
   /// LSP defines file versions as numbers that increase.
@@ -115,11 +115,11 @@ public:
 
   ~Server() override { usleep(WaitWorker); }
 
-  void eval(const std::string &Fallback, int Depth);
+  void eval(lspserver::PathRef File, int Depth);
 
-  void updateWorkspaceVersion();
+  void updateWorkspaceVersion(lspserver::PathRef File);
 
-  void switchToEvaluator();
+  void switchToEvaluator(lspserver::PathRef File);
 
   void fetchConfig();
 

--- a/lib/nixd/src/ServerController.cpp
+++ b/lib/nixd/src/ServerController.cpp
@@ -45,7 +45,7 @@ configuration::TopLevel::getInstallable(std::string Fallback) const {
                     std::string{""}};
 }
 
-void Server::updateWorkspaceVersion() {
+void Server::updateWorkspaceVersion(lspserver::PathRef File) {
   assert(Role == ServerRole::Controller &&
          "Workspace updates must happen in the Controller.");
   WorkspaceVersion++;
@@ -71,7 +71,7 @@ void Server::updateWorkspaceVersion() {
     dup2(To->readSide.get(), 0);
     dup2(From->writeSide.get(), 1);
 
-    switchToEvaluator();
+    switchToEvaluator(File);
 
   } else {
 
@@ -120,7 +120,7 @@ void Server::addDocument(lspserver::PathRef File, llvm::StringRef Contents,
   PublishDiagnostic(Notification);
 
   DraftMgr.addDraft(File, Version, Contents);
-  updateWorkspaceVersion();
+  updateWorkspaceVersion(File);
 }
 
 void Server::onInitialize(const lspserver::InitializeParams &InitializeParams,


### PR DESCRIPTION
This will send a diagnostic message to the client after the evaluation finished. Might be helpful if the user is preparing a package/NixOS module.

Fixes: #69 