### PR TITLE
flake: bump nix to 2.16.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1683560683,
-        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
+        "lastModified": 1685662779,
+        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
+        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685317056,
-        "narHash": "sha256-XyG7iSSrgqsnT90GZOvWWbJheagWvSon4LOwjGGFq6c=",
+        "lastModified": 1685938391,
+        "narHash": "sha256-96Jw6TbWDLSopt5jqCW8w1Fc1cjQyZlhfBnJ3OZGpME=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6b554aae1cf48cb39d4a61a51f826859027a93e2",
+        "rev": "31cd1b4afbaf0b1e81272ee9c31d1ab606503aed",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1682879489,
-        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "lastModified": 1685564631,
+        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
         "type": "github"
       },
       "original": {

--- a/lib/nixd/src/AST.cpp
+++ b/lib/nixd/src/AST.cpp
@@ -1,4 +1,5 @@
 #include "nixd/AST.h"
+#include "canon-path.hh"
 #include "nixd/CallbackExpr.h"
 #include "nixd/Diagnostic.h"
 #include "nixd/Expr.h"
@@ -27,7 +28,8 @@ EvalAST::EvalAST(nix::Expr *Root) : Cxt(ASTContext()) {
 
 void EvalAST::injectAST(nix::EvalState &State, lspserver::PathRef Path) {
   nix::Value DummyValue{};
-  State.cacheFile(Path.str(), Path.str(), Root, DummyValue);
+  State.cacheFile(nix::CanonPath(Path.str()), nix::CanonPath(Path.str()), Root,
+                  DummyValue);
 }
 
 nix::Value EvalAST::searchUpValue(const nix::Expr *Expr) const {

--- a/lib/nixd/src/AST.cpp
+++ b/lib/nixd/src/AST.cpp
@@ -1,5 +1,4 @@
 #include "nixd/AST.h"
-#include "canon-path.hh"
 #include "nixd/CallbackExpr.h"
 #include "nixd/Diagnostic.h"
 #include "nixd/Expr.h"
@@ -7,6 +6,7 @@
 #include "lspserver/Logger.h"
 #include "lspserver/Protocol.h"
 
+#include <nix/canon-path.hh>
 #include <nix/nixexpr.hh>
 
 #include <cstddef>

--- a/lib/nixd/src/EvalDraftStore.cpp
+++ b/lib/nixd/src/EvalDraftStore.cpp
@@ -24,8 +24,8 @@ EvalDraftStore::injectFiles(const nix::ref<nix::EvalState> &State) noexcept {
     auto Draft = getDraft(ActiveFile).value();
     try {
       std::filesystem::path AFPath = ActiveFile;
-      auto *FileAST =
-          State->parseExprFromString(*Draft.Contents, AFPath.remove_filename());
+      auto *FileAST = State->parseExprFromString(
+          *Draft.Contents, nix::CanonPath(AFPath.remove_filename().string()));
       EAF.insert({ActiveFile, nix::make_ref<EvalAST>(FileAST)});
       EAF.at(ActiveFile)->preparePositionLookup(*State);
       EAF.at(ActiveFile)->prepareParentTable();

--- a/lib/nixd/test/ast.cpp
+++ b/lib/nixd/test/ast.cpp
@@ -1,12 +1,12 @@
 #include <gtest/gtest.h>
 
-#include "canon-path.hh"
 #include "lspserver/Protocol.h"
 
 #include "nixd/AST.h"
 
 #include "nixutil.h"
 
+#include <nix/canon-path.hh>
 #include <nix/eval.hh>
 
 namespace nixd {

--- a/lib/nixd/test/ast.cpp
+++ b/lib/nixd/test/ast.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include "canon-path.hh"
 #include "lspserver/Protocol.h"
 
 #include "nixd/AST.h"
@@ -15,7 +16,7 @@ TEST(AST, lookupPosition) {
 
   InitNix INix;
   auto State = INix.getDummyState();
-  auto *RawExpr = State->parseExprFromString(NixSrc, "/");
+  auto *RawExpr = State->parseExprFromString(NixSrc, nix::CanonPath("/"));
   auto AST = EvalAST(RawExpr);
 
   AST.preparePositionLookup(*State);

--- a/lib/nixd/test/diagnostic.cpp
+++ b/lib/nixd/test/diagnostic.cpp
@@ -1,10 +1,10 @@
 #include "nixd/Diagnostic.h"
 
-#include "canon-path.hh"
 #include "nixutil.h"
 
 #include <gtest/gtest.h>
 
+#include <nix/canon-path.hh>
 #include <nix/eval.hh>
 #include <nix/shared.hh>
 #include <nix/store-api.hh>

--- a/lib/nixd/test/diagnostic.cpp
+++ b/lib/nixd/test/diagnostic.cpp
@@ -1,5 +1,6 @@
 #include "nixd/Diagnostic.h"
 
+#include "canon-path.hh"
 #include "nixutil.h"
 
 #include <gtest/gtest.h>
@@ -33,7 +34,7 @@ TEST(Diagnostic, ConstructFromParseError) {
   DiagnosticTest T;
   auto State = T.getDummyStore();
   try {
-    State->parseExprFromString(ParseErrorNix, "/");
+    State->parseExprFromString(ParseErrorNix, nix::CanonPath("/"));
   } catch (const nix::ParseError &PE) {
     auto Diagnostics = mkDiagnostics(PE);
     ASSERT_TRUE(Diagnostics.size() != 0);

--- a/lib/nixd/test/expr.cpp
+++ b/lib/nixd/test/expr.cpp
@@ -1,11 +1,11 @@
 #include <gtest/gtest.h>
 
-#include "canon-path.hh"
 #include "nixutil.h"
 
 #include "nixd/CallbackExpr.h"
 #include "nixd/Expr.h"
 
+#include <nix/canon-path.hh>
 #include <nix/eval.hh>
 #include <nix/shared.hh>
 

--- a/lib/nixd/test/expr.cpp
+++ b/lib/nixd/test/expr.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include "canon-path.hh"
 #include "nixutil.h"
 
 #include "nixd/CallbackExpr.h"
@@ -36,7 +37,7 @@ a
   } Visitor;
 
   auto State = Inix.getDummyState();
-  auto *ASTRoot = State->parseExprFromString(NixSrc, "/");
+  auto *ASTRoot = State->parseExprFromString(NixSrc, nix::CanonPath("/"));
   ASSERT_TRUE(Visitor.traverseExpr(ASTRoot));
   ASSERT_TRUE(Visitor.VisitedWith);
   ASSERT_TRUE(Visitor.VisitedLet);
@@ -88,7 +89,7 @@ rec {
   } Visitor;
 
   auto State = N.getDummyState();
-  auto *ASTRoot = State->parseExprFromString(NixSrc, "/");
+  auto *ASTRoot = State->parseExprFromString(NixSrc, nix::CanonPath("/"));
   ASSERT_TRUE(Visitor.traverseExpr(ASTRoot));
 #define NIX_EXPR(EXPR) ASSERT_TRUE(Visitor.Visited##EXPR);
 #include "nixd/NixASTNodes.inc"
@@ -144,7 +145,7 @@ rec {
       *Cxt,
       [](const nix::Expr *, const nix::EvalState &, const nix::Env &,
          const nix::Value &) {},
-      MyState->parseExprFromString(NixSrc, "/"));
+      MyState->parseExprFromString(NixSrc, nix::CanonPath("/")));
   Visitor.traverseExpr(CallbackExprRoot);
 }
 
@@ -152,7 +153,7 @@ void mkLookupTest(const char *NixSrc, uint32_t Line, uint32_t Column) {
   InitNix Inix;
 
   auto State = Inix.getDummyState();
-  auto *ASTRoot = State->parseExprFromString(NixSrc, "/");
+  auto *ASTRoot = State->parseExprFromString(NixSrc, nix::CanonPath("/"));
 
   auto PMap = getParentMap(ASTRoot);
 

--- a/tools/nix-ast-dump/nix-ast-dump.cpp
+++ b/tools/nix-ast-dump/nix-ast-dump.cpp
@@ -1,6 +1,6 @@
-#include "canon-path.hh"
 #include "nixd/Expr.h"
 
+#include <nix/canon-path.hh>
 #include <nix/eval.hh>
 #include <nix/nixexpr.hh>
 #include <nix/shared.hh>

--- a/tools/nix-ast-dump/nix-ast-dump.cpp
+++ b/tools/nix-ast-dump/nix-ast-dump.cpp
@@ -1,3 +1,4 @@
+#include "canon-path.hh"
 #include "nixd/Expr.h"
 
 #include <nix/eval.hh>
@@ -50,7 +51,7 @@ struct ASTDump : nixd::RecursiveASTVisitor<ASTDump> {
 int main(int argc, char *argv[]) {
   InitNix I;
   auto State = I.getDummyState();
-  const auto *E = State->parseExprFromFile(argv[1]);
+  const auto *E = State->parseExprFromFile(nix::CanonPath(argv[1]));
   ASTDump A;
   A.State = std::move(State);
   A.traverseExpr(E);


### PR DESCRIPTION
The breaking change is: we have to use nix::CanonPath() to wrap around paths.