### PR TITLE
nixd/completion/options: natively support all kinds of nixpkgs options

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -56,7 +56,45 @@ nix build -L .#
 
 We support LSP standard `workspace/configuration` for server configurations.
 
-#### Project Installable
+Configuration overview:
+
+```jsonc
+{
+  // The evaluation section, provide auto completion for dynamic bindings.
+  "eval": {
+    "target": {
+      // Accept args as "nix eval"
+      "args": [],
+      // "nix eval"
+      "installable": ""
+    },
+    // Extra depth for evaluation
+    "depth": 0,
+    // The number of workers for evaluation task.
+    "workers": 3
+  },
+  "formatting": {
+    // Which command you would like to do formatting
+    "command": "nixpkgs-fmt"
+  },
+  // Tell the language server your desired option set, for completion
+  // This is lazily evaluated.
+  "options": {
+    // Enable option completion task.
+    // If you are writting a package, disable this
+    "enable": true,
+    "target": {
+      // Accept args as "nix eval"
+      "args": [],
+      // "nix eval"
+      "installable": ""
+    }
+  }
+}
+```
+
+#### Evaluation
+
 
 Unlike any other nix lsp implementation, you may need to explicitly specify a `installable` in your workspace.
 The language server will consider the `installable` is your desired "object file", and it is the cross-file analysis pivot.
@@ -87,12 +125,19 @@ We accept the same argument as `nix eval`, and perform evaluation for language a
 
 
 ```jsonc
-"installable": {
-    "args":[
+{
+  "eval": {
+    "target": {
+      // Same as:
+      // nix eval --expr "..."
+      "args": [
         "--expr",
         "with import <nixpkgs> { }; callPackage ./some-package.nix { } "
-    ],
-    "installable":""
+      ],
+      // AttrPath
+      "installable": ""
+    }
+  }
 }
 ```
 
@@ -112,7 +157,9 @@ As for language service, we have an custom extension to nix evaluator that allow
 
 ```jsonc
 {
-    "evalDepth": 5
+    "eval": {
+      "depth": 5
+    }
 }
 ```
 
@@ -123,7 +170,9 @@ You can specify how many workers will be used for language tasks, e.g. parsing &
 
 ```jsonc
 {
-    "numWorkers": 10
+    "eval": {
+      "workers": 5
+    }
 }
 ```
 
@@ -167,17 +216,17 @@ So tldr, to use `nixd` in your flake project, you have to:
 
 Example:
 
-```json
+```jsonc
 {
-    "nixd": {
-        "installable": {
-            "args": [
-                "-f",
-                "default.nix"
-            ],
-            "installable": "devShells.x86_64-linux.llvm"
-        },
-        "evalDepth": 3
-    }
+  "eval": {
+    "target": {
+      "args": [
+        "-f",
+        "default.nix"
+      ],
+      "installable": "devShells.x86_64-linux.llvm"
+    },
+    "depth": 3
+  }
 }
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -95,6 +95,7 @@ Configuration overview:
 
 #### Evaluation
 
+##### Target
 
 Unlike any other nix lsp implementation, you may need to explicitly specify a `installable` in your workspace.
 The language server will consider the `installable` is your desired "object file", and it is the cross-file analysis pivot.
@@ -147,7 +148,7 @@ Here is the demo video that I used the above installable in my workspace:
 
 ![package](/docs/images/8d106acc-6b1a-4062-9dc7-175b09751fd0.gif)
 
-#### Evaluation Depth
+##### Depth
 
 Nix evaluator will be lazily peform evaluation on your specified task[^nix-evaluation-peformance].
 
@@ -163,7 +164,7 @@ As for language service, we have an custom extension to nix evaluator that allow
 }
 ```
 
-#### Workers
+##### Workers
 
 Nixd evals your project concurrently.
 You can specify how many workers will be used for language tasks, e.g. parsing & evaluation.
@@ -177,6 +178,65 @@ You can specify how many workers will be used for language tasks, e.g. parsing &
 ```
 
 The default value is `std::thread::hardware_concurrency()`.
+
+#### Format
+
+To configure which command will be used for formatting, you can change the "formatting" section.
+
+```jsonc
+{
+  "formatting": {
+    // The external command to be invoked for formatting
+    "command": ""
+  }
+}
+```
+
+#### Options
+
+This is our support for nixpkgs option system.
+
+Generally options are merged under a special attribute path.
+For example, NixOS options could be found at:
+
+```
+<flakeref>#nixosConfigurations.<name>.options
+```
+
+And, home-manager options also could be found at:
+
+```
+<flakeref>#homeConfigurations.<name>.options
+```
+
+In our option system, you need to specify which option set you'd like to use.
+
+```jsonc
+{
+  "options": {
+    // Disable it if you are not writting modules.
+    "enable": true,
+    "target": {
+      "args": [],
+      // Example of NixOS options.
+      "installable": "<flakeref>#nixosConfigurations.<name>.options"
+    }
+  }
+}
+```
+
+<details><summary>Options auto completion</summary>
+
+**Home-manager Options**
+
+![hm-docs](https://github.com/nix-community/nixd/assets/36667224/38039c75-379f-463f-aac8-e33ff71eea38)
+
+**NixOS Options**
+
+![nixos-option-docs](https://github.com/nix-community/nixd/assets/36667224/ca4ed4dc-469f-4c2b-9dea-7beab9a417e8)
+
+
+</details>
 
 
 ### FAQ

--- a/lib/nixd/include/nixd/EvalDraftStore.h
+++ b/lib/nixd/include/nixd/EvalDraftStore.h
@@ -84,13 +84,14 @@ struct IValueEvalSession {
     return IVC->getEvalState();
   };
 
-  void eval(const std::string &Installable, int Depth = 0) const {
+  nix::Value *eval(const std::string &Installable, int Depth = 0) const {
     lspserver::log("evaluation on installable {0}, requested depth: {1}",
                    Installable, Depth);
     auto IValue = nix::InstallableValue::require(
         IVC->parseInstallable(IVC->getStore(), Installable));
     auto [Value, _] = IValue->toValue(*getState());
     nix::forceValueDepth(*IVC->getEvalState(), *Value, Depth);
+    return Value;
   }
 };
 

--- a/lib/nixd/include/nixd/JSONSerialization.h
+++ b/lib/nixd/include/nixd/JSONSerialization.h
@@ -56,7 +56,7 @@ struct TopLevel {
   struct Formatting {
     std::optional<std::string> command;
   };
-  std::optional<Formatting> formartting;
+  std::optional<Formatting> formatting;
 
   struct Options {
     std::optional<bool> enable;
@@ -66,8 +66,8 @@ struct TopLevel {
   std::optional<Options> options;
 
   [[nodiscard]] std::string getFormatCommand() const {
-    if (formartting.has_value() && formartting->command.has_value())
-      return formartting->command.value();
+    if (formatting.has_value() && formatting->command.has_value())
+      return formatting->command.value();
     return "nixpkgs-fmt";
   }
 

--- a/lib/nixd/include/nixd/nix/Option.h
+++ b/lib/nixd/include/nixd/nix/Option.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <nix/eval.hh>
+
+#include <optional>
+#include <string>
+
+namespace nix::nixd {
+struct OptionInfo {
+  std::optional<std::string> Type;
+  std::optional<std::string> Description;
+};
+
+OptionInfo optionInfo(nix::EvalState &State, nix::Value &V);
+} // namespace nix::nixd

--- a/lib/nixd/include/nixd/nix/Value.h
+++ b/lib/nixd/include/nixd/nix/Value.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <nix/attr-path.hh>
+#include <nix/eval.hh>
+
+namespace nix::nixd {
+
+bool isOption(EvalState &State, Value &V);
+
+std::optional<std::string> attrPathStr(nix::EvalState &State, nix::Value &V,
+                                       const std::string &AttrPath) noexcept;
+
+} // namespace nix::nixd

--- a/lib/nixd/meson.build
+++ b/lib/nixd/meson.build
@@ -9,6 +9,8 @@ nixd_server_lib = library('nixd-lsp'
   , 'src/ServerController.cpp'
   , 'src/ServerWorker.cpp'
   , 'src/nix/EvalState.cpp'
+  , 'src/nix/Option.cpp'
+  , 'src/nix/Value.cpp'
   ]
 , include_directories: nixd_server_inc
 , dependencies: [ llvm

--- a/lib/nixd/src/JSONSerialization.cpp
+++ b/lib/nixd/src/JSONSerialization.cpp
@@ -1,18 +1,41 @@
 #include "nixd/JSONSerialization.h"
 
+#include "lspserver/Logger.h"
+
+#include <llvm/Support/JSON.h>
+
 namespace nixd {
 
 using namespace llvm::json;
 
 namespace configuration {
 
+bool fromJSON(const Value &Params, TopLevel::Eval &R, Path P) {
+  ObjectMapper O(Params, P);
+  return O && O.map("depth", R.depth) && O.map("target", R.target) &&
+         O.map("workers", R.workers);
+}
+
+bool fromJSON(const Value &Params, TopLevel::Formatting &R, Path P) {
+  ObjectMapper O(Params, P);
+  return O && O.map("command", R.command);
+}
+
+bool fromJSON(const Value &Params, TopLevel::Options &R, Path P) {
+  ObjectMapper O(Params, P);
+  return O && O.map("enable", R.enable) && O.map("target", R.target);
+}
+
 bool fromJSON(const Value &Params, TopLevel &R, Path P) {
-  const auto *PA = Params.getAsArray();
-  auto X = PA->front();
+  Value X = Params;
+  if (Params.kind() == Value::Array) {
+    const auto *PA = Params.getAsArray();
+    X = PA->front();
+  }
   ObjectMapper O(X, P);
-  return O && O.map("installable", R.installable) &&
-         O.map("evalDepth", R.evalDepth) && O.map("numWorkers", R.numWorkers) &&
-         O.map("formatCommand", R.formatCommand);
+
+  return O && O.map("eval", R.eval) && O.map("formatting", R.formartting) &&
+         O.map("options", R.options);
 }
 
 bool fromJSON(const Value &Params, std::list<std::string> &R, Path P) {
@@ -48,6 +71,14 @@ Value toJSON(const Diagnostics &R) {
   Base.getAsObject()->insert({"Params", R.Params});
   return Base;
 }
+
+bool fromJSON(const Value &Params, AttrPathParams &R, Path P) {
+  ObjectMapper O(Params, P);
+  return O && O.map("Path", R.Path);
+}
+
+Value toJSON(const AttrPathParams &R) { return Object{{"Path", R.Path}}; }
+
 } // namespace ipc
 
 } // namespace nixd
@@ -90,7 +121,9 @@ Value toJSON(const CompletionParams &R) {
 
 bool fromJSON(const Value &Params, CompletionItem &R, llvm::json::Path P) {
   ObjectMapper O(Params, P);
-  return O && O.map("label", R.label) && O.map("kind", R.kind);
+  return O && O.map("label", R.label) && O.map("kind", R.kind) &&
+         O.mapOptional("detail", R.detail) &&
+         O.mapOptional("documentation", R.documentation);
 }
 
 bool fromJSON(const Value &Params, CompletionList &R, llvm::json::Path P) {

--- a/lib/nixd/src/JSONSerialization.cpp
+++ b/lib/nixd/src/JSONSerialization.cpp
@@ -34,7 +34,7 @@ bool fromJSON(const Value &Params, TopLevel &R, Path P) {
   }
   ObjectMapper O(X, P);
 
-  return O && O.map("eval", R.eval) && O.map("formatting", R.formartting) &&
+  return O && O.map("eval", R.eval) && O.map("formatting", R.formatting) &&
          O.map("options", R.options);
 }
 

--- a/lib/nixd/src/ServerWorker.cpp
+++ b/lib/nixd/src/ServerWorker.cpp
@@ -301,6 +301,9 @@ void Server::onWorkerCompletionOptions(
 
       auto &State = *OptionIES->getState();
 
+      if (IsOption(State, *V))
+        return;
+
       for (auto Attr : *V->attrs) {
         if (IsOption(State, *Attr.value)) {
           auto OI = GetOptionInfo(State, *Attr.value);

--- a/lib/nixd/src/ServerWorker.cpp
+++ b/lib/nixd/src/ServerWorker.cpp
@@ -232,7 +232,6 @@ void Server::onWorkerCompletionOptions(
     lspserver::Callback<llvm::json::Value> Reply) {
   using namespace lspserver;
   using namespace nix::nixd;
-  // auto RequestedFile = Params.textDocument.uri.file().str();
   ReplyRAII<CompletionList> RR(std::move(Reply));
 
   try {

--- a/lib/nixd/src/ServerWorker.cpp
+++ b/lib/nixd/src/ServerWorker.cpp
@@ -4,17 +4,28 @@
 #include "nixd/Server.h"
 
 #include "lspserver/Connection.h"
+#include "lspserver/Logger.h"
 #include "lspserver/Protocol.h"
+#include "lspserver/SourceCode.h"
 
+#include <nix/attr-path.hh>
 #include <nix/error.hh>
 #include <nix/eval.hh>
 #include <nix/globals.hh>
 #include <nix/nixexpr.hh>
 #include <nix/shared.hh>
 #include <nix/store-api.hh>
+#include <nix/symbol-table.hh>
 #include <nix/util.hh>
+#include <nix/value.hh>
 
+#include <llvm/ADT/StringRef.h>
+
+#include <exception>
+#include <optional>
 #include <stdexcept>
+#include <string>
+#include <string_view>
 
 namespace nixd {
 
@@ -68,11 +79,9 @@ CompletionHelper::fromEnvRecursive(const nix::SymbolTable &STable,
   return Result;
 }
 
-void Server::switchToEvaluator(lspserver::PathRef File) {
+void Server::initWorker() {
   assert(Role == ServerRole::Controller &&
          "Must switch from controller's fork!");
-  Role = ServerRole::Evaluator;
-
   nix::initNix();
   nix::initLibStore();
   nix::initPlugins();
@@ -81,14 +90,34 @@ void Server::switchToEvaluator(lspserver::PathRef File) {
   /// Basically communicate with the controller in standard mode. because we do
   /// not support "lit-test" outbound port.
   switchStreamStyle(lspserver::JSONStreamStyle::Standard);
+}
 
-  // unregister "Procs" in worker process, they are managed by controller
-  for (auto &Worker : Workers)
-    Worker->Pid.release();
-
+void Server::switchToEvaluator(lspserver::PathRef File) {
+  initWorker();
+  Role = ServerRole::Evaluator;
   WorkerDiagnostic = mkOutNotifiction<ipc::Diagnostics>("nixd/ipc/diagnostic");
+  evalInstallable(File, Config.getEvalDepth());
+}
 
-  eval(File, Config.getEvalDepth());
+void Server::switchToOptionProvider() {
+  initWorker();
+  Role = ServerRole::OptionProvider;
+
+  if (!Config.options.has_value() || !Config.options->enable.value_or(false) ||
+      !Config.options->target.has_value())
+    return;
+  try {
+    auto [Args, Installable] =
+        configuration::TopLevel::getInstallable(Config.options->target.value());
+    auto SessionOption = std::make_unique<IValueEvalSession>();
+    SessionOption->parseArgs(Args);
+    OptionAttrSet = SessionOption->eval(Installable);
+    OptionIES = std::move(SessionOption);
+    lspserver::log("options are ready");
+  } catch (std::exception &E) {
+    lspserver::elog("exception {0} encountered while evaluating options",
+                    stripANSI(E.what()));
+  }
 }
 
 lspserver::PublishDiagnosticsParams
@@ -104,12 +133,19 @@ Server::diagNixError(lspserver::PathRef Path, const nix::BaseError &NixErr,
   return Notification;
 }
 
-void Server::eval(lspserver::PathRef File, int Depth = 0) {
-  assert(Role != ServerRole::Controller &&
-         "eval must be called in child workers.");
+void Server::evalInstallable(lspserver::PathRef File, int Depth = 0) {
+  assert(Role != ServerRole::Controller && "must be called in child workers.");
   auto Session = std::make_unique<IValueEvalSession>();
 
-  auto [Args, Installable] = Config.getInstallable("");
+  nix::Strings Args;
+  std::string Installable;
+  if (!Config.eval.has_value() || !Config.eval->target) {
+    Args = {"--file", std::string(File)};
+    Installable = "";
+  } else {
+    std::tie(Args, Installable) =
+        configuration::TopLevel::getInstallable(Config.eval->target.value());
+  }
 
   Session->parseArgs(Args);
 
@@ -187,6 +223,106 @@ void Server::onWorkerHover(const lspserver::TextDocumentPositionParams &Params,
           HoverText = llvm::formatv("`{0}`", ExprName);
         }
       });
+}
+
+void Server::onWorkerCompletionOptions(
+    const ipc::AttrPathParams &Params,
+    lspserver::Callback<llvm::json::Value> Reply) {
+  using namespace lspserver;
+  // auto RequestedFile = Params.textDocument.uri.file().str();
+  ReplyRAII<CompletionList> RR(std::move(Reply));
+
+  try {
+    CompletionList List;
+    List.isIncomplete = false;
+    List.items = CompletionHelper::Items{};
+
+    auto &Items = List.items;
+
+    if (OptionAttrSet->type() == nix::ValueType::nAttrs) {
+      nix::Value *V = OptionAttrSet;
+      if (!Params.Path.empty()) {
+        auto &Bindings(*OptionIES->getState()->allocBindings(0));
+        V = nix::findAlongAttrPath(*OptionIES->getState(), Params.Path,
+                                   Bindings, *OptionAttrSet)
+                .first;
+      }
+
+      OptionIES->getState()->forceValue(*V, nix::noPos);
+
+      if (V->type() != nix::ValueType::nAttrs)
+        return;
+
+      auto IsOption = [](nix::EvalState &State, nix::Value &V) {
+        State.forceValue(V, nix::noPos);
+        if (V.type() != nix::ValueType::nAttrs)
+          return false;
+        bool HasDesc = false;
+        bool HasType = false;
+        for (auto Attr : *V.attrs) {
+          auto Name = State.symbols[Attr.name];
+          if (std::string_view(Name) == "description")
+            HasDesc = true;
+          if (std::string_view(Name) == "type")
+            HasType = true;
+        }
+        return HasType && HasDesc;
+      };
+
+      struct OptionInfo {
+        std::optional<std::string> Type;
+        std::optional<std::string> Description;
+      } Info;
+
+      auto GetAttrPathString =
+          [](nix::EvalState &State, nix::Value &V,
+             const std::string &AttrPath) -> std::optional<std::string> {
+        try {
+          auto [VPath, _] = nix::findAlongAttrPath(State, AttrPath,
+                                                   *State.allocBindings(0), V);
+          if (VPath->type() == nix::ValueType::nString)
+            return std::string(State.forceStringNoCtx(*VPath, nix::noPos, ""));
+        } catch (std::exception &E) {
+          return std::nullopt;
+        }
+        return std::nullopt;
+      };
+
+      auto GetOptionInfo = [&GetAttrPathString](nix::EvalState &State,
+                                                nix::Value &V) {
+        OptionInfo Info;
+        Info.Type = GetAttrPathString(State, V, "type.name");
+        Info.Description = GetAttrPathString(State, V, "description");
+        if (!Info.Description.has_value())
+          Info.Description = GetAttrPathString(State, V, "description.text");
+
+        return Info;
+      };
+
+      auto &State = *OptionIES->getState();
+
+      for (auto Attr : *V->attrs) {
+        if (IsOption(State, *Attr.value)) {
+          auto OI = GetOptionInfo(State, *Attr.value);
+          Items.emplace_back(CompletionItem{
+              .label = State.symbols[Attr.name],
+              .kind = CompletionItemKind::Constructor,
+              .detail = OI.Type.value_or(""),
+              .documentation = MarkupContent{MarkupKind::Markdown,
+                                             OI.Description.value_or("")}});
+        } else {
+          Items.emplace_back(
+              CompletionItem{.label = OptionIES->getState()->symbols[Attr.name],
+                             .kind = CompletionItemKind::Class,
+                             .detail = "{...}",
+                             .documentation = std::nullopt});
+        }
+      }
+      RR.Response = std::move(List);
+    }
+  } catch (std::exception &E) {
+    RR.Response = error(E.what());
+  }
 }
 
 void Server::onWorkerCompletion(const lspserver::CompletionParams &Params,

--- a/lib/nixd/src/nix/Option.cpp
+++ b/lib/nixd/src/nix/Option.cpp
@@ -1,0 +1,16 @@
+#include "nixd/nix/Option.h"
+#include "nixd/nix/Value.h"
+
+namespace nix::nixd {
+
+OptionInfo optionInfo(nix::EvalState &State, nix::Value &V) {
+  OptionInfo Info;
+  Info.Type = attrPathStr(State, V, "type.name");
+  Info.Description = attrPathStr(State, V, "description");
+  if (!Info.Description.has_value())
+    Info.Description = attrPathStr(State, V, "description.text");
+
+  return Info;
+};
+
+} // namespace nix::nixd

--- a/lib/nixd/src/nix/Value.cpp
+++ b/lib/nixd/src/nix/Value.cpp
@@ -1,0 +1,34 @@
+#include "nixd/nix/Value.h"
+
+namespace nix::nixd {
+
+bool isOption(EvalState &State, Value &V) {
+  State.forceValue(V, noPos);
+  if (V.type() != ValueType::nAttrs)
+    return false;
+  bool HasDesc = false;
+  bool HasType = false;
+  for (auto Attr : *V.attrs) {
+    auto Name = State.symbols[Attr.name];
+    if (std::string_view(Name) == "description")
+      HasDesc = true;
+    if (std::string_view(Name) == "type")
+      HasType = true;
+  }
+  return HasType && HasDesc;
+};
+
+std::optional<std::string> attrPathStr(nix::EvalState &State, nix::Value &V,
+                                       const std::string &AttrPath) noexcept {
+  try {
+    auto [VPath, _] =
+        findAlongAttrPath(State, AttrPath, *State.allocBindings(0), V);
+    if (VPath->type() == nix::ValueType::nString)
+      return std::string(State.forceStringNoCtx(*VPath, nix::noPos, ""));
+  } catch (std::exception &E) {
+  } catch (...) {
+  }
+  return std::nullopt;
+};
+
+} // namespace nix::nixd

--- a/tools/nixd/test/workspace-configuration-eval-depth.md
+++ b/tools/nixd/test/workspace-configuration-eval-depth.md
@@ -42,14 +42,16 @@ The server should parse it correctly and do not crash.
    "id":1,
    "result":[
       {
-         "installable":{
-            "args":[
-               "--file",
-               "/deeper.nix"
-            ],
-            "installable":""
-         },
-         "evalDepth": 3
+         "eval":{
+            "target": {
+               "args":[
+                  "--file",
+                  "/deeper.nix"
+               ],
+               "installable":""
+            },
+            "depth": 3
+         }
       }
    ]
 }


### PR DESCRIPTION
Fixes: #87

TODO:

- [x] Docs update

Tested home-manager & nixos options:

## Home-manager:

![hm-docs](https://github.com/nix-community/nixd/assets/36667224/38039c75-379f-463f-aac8-e33ff71eea38)

## NixOS

![nixos-option-docs](https://github.com/nix-community/nixd/assets/36667224/ca4ed4dc-469f-4c2b-9dea-7beab9a417e8)
