### PR TITLE
nixd: goto definition for derivations

### DIFF
--- a/lib/nixd/include/nixd/nix/Value.h
+++ b/lib/nixd/include/nixd/nix/Value.h
@@ -7,6 +7,8 @@ namespace nix::nixd {
 
 bool isOption(EvalState &State, Value &V);
 
+bool isDerivation(EvalState &State, Value &V);
+
 std::optional<std::string> attrPathStr(nix::EvalState &State, nix::Value &V,
                                        const std::string &AttrPath) noexcept;
 

--- a/lib/nixd/src/nix/Value.cpp
+++ b/lib/nixd/src/nix/Value.cpp
@@ -1,5 +1,7 @@
 #include "nixd/nix/Value.h"
 
+#include <nix/eval.hh>
+
 namespace nix::nixd {
 
 bool isOption(EvalState &State, Value &V) {
@@ -11,6 +13,16 @@ bool isOption(EvalState &State, Value &V) {
   auto S = attrPathStr(State, V, "_type");
   return S && S.value() == "option";
 };
+
+bool isDerivation(EvalState &State, Value &V) {
+  State.forceValue(V, noPos);
+  if (V.type() != ValueType::nAttrs)
+    return false;
+
+  // Derivations has a special attribute "type" == "derivation"
+  auto S = attrPathStr(State, V, "type");
+  return S && S.value() == "derivation";
+}
 
 std::optional<std::string> attrPathStr(nix::EvalState &State, nix::Value &V,
                                        const std::string &AttrPath) noexcept {

--- a/tools/nixd/test/goto-definition-derivation.md
+++ b/tools/nixd/test/goto-definition-derivation.md
@@ -1,0 +1,91 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+Testing this nix file, a dummy derivation.
+
+```nix
+let
+  foo = {
+    type = "derivation";
+    meta.position = "/foo.nix:4";
+  };
+in
+foo
+#^ expected location: foo.nix:4
+```
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "textDocument/didOpen",
+    "params": {
+        "textDocument": {
+            "uri": "file:///derivation.nix",
+            "languageId": "nix",
+            "version": 1,
+            "text": "let\r\n  foo = {\r\n    type = \"derivation\";\r\n    meta.position = \"\/foo.nix:4\";\r\n  };\r\nin\r\nfoo"
+        }
+    }
+}
+```
+
+<-- textDocument/definition
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":1,
+   "method":"textDocument/definition",
+   "params":{
+      "textDocument":{
+         "uri":"file:///derivation.nix"
+      },
+      "position":{
+         "line":6,
+         "character":0
+      }
+   }
+}
+```
+
+
+```
+     CHECK: "id": 1,
+CHECK-NEXT:   "jsonrpc": "2.0",
+CHECK-NEXT:   "result": {
+CHECK-NEXT:     "range": {
+CHECK-NEXT:       "end": {
+CHECK-NEXT:         "character": 0,
+CHECK-NEXT:         "line": 4
+CHECK-NEXT:       },
+CHECK-NEXT:       "start": {
+CHECK-NEXT:         "character": 0,
+CHECK-NEXT:         "line": 4
+CHECK-NEXT:       }
+CHECK-NEXT:     },
+CHECK-NEXT:     "uri": "file:///foo.nix"
+CHECK-NEXT:   }
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```


### PR DESCRIPTION
Fixes: #112

This is a cool feature that brings you to the position where a package defined.

![goto-def-pkg-2](https://github.com/nix-community/nixd/assets/36667224/726c711f-cf75-48f4-9f3b-40dd1b9f53be)
