### PR TITLE
lspserver: remove the named mutex when logger startup

### DIFF
--- a/lib/lspserver/include/lspserver/Logger.h
+++ b/lib/lspserver/include/lspserver/Logger.h
@@ -4,6 +4,9 @@
 #include <llvm/Support/Error.h>
 #include <llvm/Support/FormatAdapters.h>
 #include <llvm/Support/FormatVariadic.h>
+
+#include <boost/interprocess/sync/named_mutex.hpp>
+
 #include <mutex>
 
 namespace lspserver {
@@ -101,9 +104,13 @@ public:
 
 // Logs to an output stream, such as stderr.
 class StreamLogger : public Logger {
+  static constexpr const char *StreamLockName = "nixd.ipc.mutex.log";
+
 public:
   StreamLogger(llvm::raw_ostream &Logs, Logger::Level MinLevel)
-      : MinLevel(MinLevel), Logs(Logs) {}
+      : MinLevel(MinLevel), Logs(Logs) {
+    boost::interprocess::named_mutex::remove(StreamLockName);
+  }
 
   /// Write a line to the logging stream.
   void log(Level, const char *Fmt,

--- a/lib/lspserver/src/Logger.cpp
+++ b/lib/lspserver/src/Logger.cpp
@@ -58,7 +58,7 @@ void StreamLogger::log(Logger::Level Level, const char *Fmt,
   if (Level < MinLevel)
     return;
   llvm::sys::TimePoint<> Timestamp = std::chrono::system_clock::now();
-  named_mutex NamedMutex(open_or_create, "nixd.ipc.mutex.log");
+  named_mutex NamedMutex(open_or_create, StreamLockName);
 
   scoped_lock<named_mutex> Lock(NamedMutex);
   Logs << llvm::formatv("{0}[{1:%H:%M:%S.%L}] {2}: {3}\n", indicator(Level),


### PR DESCRIPTION
This will release the lock to avoid deadlocks on crashed program.