### PR TITLE
editors/nvim-lsp: fix don't display diagnostic information

### DIFF
--- a/editors/nvim-lsp.nix
+++ b/editors/nvim-lsp.nix
@@ -32,43 +32,43 @@ let
     -- Basic options --
     -------------------
     local options = {
-      clipboard = "unnamedplus",
-      mouse = "a",
-      undofile = true,
-      ignorecase = true,
-      showmode = false,
-      showtabline = 2,
-      smartindent = true,
-      autoindent = true,
-      swapfile = false,
-      hidden = true, --default on
-      expandtab = true,
-      cmdheight = 1,
-      shiftwidth = 2, --insert 2 spaces for each indentation
-      tabstop = 2, --insert 2 spaces for a tab
-      cursorline = true, --Highlight the line where the cursor is located
-      cursorcolumn = false,
-      number = true,
-      numberwidth = 4,
-      relativenumber = true,
-      scrolloff = 8,
-      updatetime = 50, -- faster completion (4000ms default)
+    	clipboard = "unnamedplus",
+    	mouse = "a",
+    	undofile = true,
+    	ignorecase = true,
+    	showmode = false,
+    	showtabline = 2,
+    	smartindent = true,
+    	autoindent = true,
+    	swapfile = false,
+    	hidden = true, --default on
+    	expandtab = true,
+    	cmdheight = 1,
+    	shiftwidth = 2, --insert 2 spaces for each indentation
+    	tabstop = 2, --insert 2 spaces for a tab
+    	cursorline = true, --Highlight the line where the cursor is located
+    	cursorcolumn = false,
+    	number = true,
+    	numberwidth = 4,
+    	relativenumber = true,
+    	scrolloff = 8,
+    	updatetime = 50, -- faster completion (4000ms default)
     }
 
     for k, v in pairs(options) do
-      vim.opt[k] = v
+    	vim.opt[k] = v
     end
 
     ----------------------
     -- About treesitter --
     ----------------------
-    require("nvim-treesitter.configs").setup ({
-      highlight = {
-        enable = true,
-      },
-      indent = {
-        enable = true,
-      },
+    require("nvim-treesitter.configs").setup({
+    	highlight = {
+    		enable = true,
+    	},
+    	indent = {
+    		enable = true,
+    	},
     })
 
     ---------------
@@ -84,11 +84,6 @@ let
     end
 
     require("luasnip/loaders/from_vscode").lazy_load()
-
-    local check_backspace = function()
-    	local col = vim.fn.col(".") - 1
-    	return col == 0 or vim.fn.getline("."):sub(col, col):match("%s")
-    end
 
     local kind_icons = {
     	Text = "󰊄",
@@ -124,36 +119,24 @@ let
     			luasnip.lsp_expand(args.body) -- For `luasnip` users.
     		end,
     	},
-    	mapping = {
-    		["<C-k>"] = cmp.mapping.select_prev_item(),
-    		["<C-j>"] = cmp.mapping.select_next_item(),
-    		["<C-b>"] = cmp.mapping(cmp.mapping.scroll_docs(-1), { "i", "c" }),
-    		["<C-f>"] = cmp.mapping(cmp.mapping.scroll_docs(1), { "i", "c" }),
-    		["<C-Space>"] = cmp.mapping(cmp.mapping.complete(), { "i", "c" }),
-    		["<C-y>"] = cmp.config.disable, -- Specify `cmp.config.disable` if you want to remove the default `<C-y>` mapping.
-    		["<C-e>"] = cmp.mapping({
-    			i = cmp.mapping.abort(),
-    			c = cmp.mapping.close(),
+    	mapping = cmp.mapping.preset.insert({
+    		["<C-u>"] = cmp.mapping.scroll_docs(-4), -- Up
+    		["<C-d>"] = cmp.mapping.scroll_docs(4), -- Down
+    		-- C-b (back) C-f (forward) for snippet placeholder navigation.
+    		["<C-Space>"] = cmp.mapping.complete(),
+    		["<CR>"] = cmp.mapping.confirm({
+    			behavior = cmp.ConfirmBehavior.Replace,
+    			select = true,
     		}),
-    		-- Accept currently selected item. If none selected, `select` first item.
-    		-- Set `select` to `false` to only confirm explicitly selected items.
-    		["<CR>"] = cmp.mapping.confirm({ select = true }),
     		["<Tab>"] = cmp.mapping(function(fallback)
     			if cmp.visible() then
     				cmp.select_next_item()
-    			elseif luasnip.expandable() then
-    				luasnip.expand()
     			elseif luasnip.expand_or_jumpable() then
     				luasnip.expand_or_jump()
-    			elseif check_backspace() then
-    				fallback()
     			else
     				fallback()
     			end
-    		end, {
-    			"i",
-    			"s",
-    		}),
+    		end, { "i", "s" }),
     		["<S-Tab>"] = cmp.mapping(function(fallback)
     			if cmp.visible() then
     				cmp.select_prev_item()
@@ -162,11 +145,8 @@ let
     			else
     				fallback()
     			end
-    		end, {
-    			"i",
-    			"s",
-    		}),
-    	},
+    		end, { "i", "s" }),
+    	}),
     	formatting = {
     		fields = { "kind", "abbr", "menu" },
     		format = function(entry, vim_item)
@@ -202,20 +182,41 @@ let
     	},
     })
 
-    local capabilities = require("cmp_nvim_lsp").default_capabilities()
-
     -------------------
     -- About null-ls --
     -------------------
-    require("null-ls").setup({
-    	sources = {
-    		-- you must download code formatter by yourself!
-    		require("null-ls").builtins.formatting.nixpkgs_fmt,
-    	},
-    })
-    ---------------------
-    -- About lspconfig --
-    ---------------------
+    -- format(async)
+    local async_formatting = function(bufnr)
+    	bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+    	vim.lsp.buf_request(
+    		bufnr,
+    		"textDocument/formatting",
+    		vim.lsp.util.make_formatting_params({}),
+    		function(err, res, ctx)
+    			if err then
+    				local err_msg = type(err) == "string" and err or err.message
+    				-- you can modify the log message / level (or ignore it completely)
+    				vim.notify("formatting: " .. err_msg, vim.log.levels.WARN)
+    				return
+    			end
+
+    			-- don't apply results if buffer is unloaded or has been modified
+    			if not vim.api.nvim_buf_is_loaded(bufnr) or vim.api.nvim_buf_get_option(bufnr, "modified") then
+    				return
+    			end
+
+    			if res then
+    				local client = vim.lsp.get_client_by_id(ctx.client_id)
+    				vim.lsp.util.apply_text_edits(res, bufnr, client and client.offset_encoding or "utf-16")
+    				vim.api.nvim_buf_call(bufnr, function()
+    					vim.cmd("silent noautocmd update")
+    				end)
+    			end
+    		end
+    	)
+    end
+    local augroup = vim.api.nvim_create_augroup("LspFormatting", {})
     local lsp_formatting = function(bufnr)
     	vim.lsp.buf.format({
     		filter = function(client)
@@ -225,54 +226,39 @@ let
     		bufnr = bufnr,
     	})
     end
-
-    -- if you want to set up formatting on save, you can use this as a callback
-    local augroup = vim.api.nvim_create_augroup("LspFormatting", {})
-
-    local on_attach = function(client, bufnr)
-    	-- Mappings.
-    	-- See `:help vim.lsp.*` for documentation on any of the below functions
-    	local bufopts = { noremap = true, silent = true, buffer = bufnr }
-    	vim.keymap.set("n", "gD", vim.lsp.buf.declaration, bufopts)
-    	vim.keymap.set("n", "gd", vim.lsp.buf.definition, bufopts)
-    	vim.keymap.set("n", "K", vim.lsp.buf.hover, bufopts)
-    	vim.keymap.set("n", "gi", vim.lsp.buf.implementation, bufopts)
-    	vim.keymap.set("n", "<C-k>", vim.lsp.buf.signature_help, bufopts)
-    	vim.keymap.set("n", "<space>wa", vim.lsp.buf.add_workspace_folder, bufopts)
-    	vim.keymap.set("n", "<space>wr", vim.lsp.buf.remove_workspace_folder, bufopts)
-    	vim.keymap.set("n", "<space>wl", function()
-    		print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
-    	end, bufopts)
-    	vim.keymap.set("n", "<space>D", vim.lsp.buf.type_definition, bufopts)
-    	vim.keymap.set("n", "<space>rn", vim.lsp.buf.rename, bufopts)
-    	vim.keymap.set("n", "<space>ca", vim.lsp.buf.code_action, bufopts)
-    	vim.keymap.set("n", "gr", vim.lsp.buf.references, bufopts)
-    	-- add to your shared on_attach callback
-    	if client.supports_method("textDocument/formatting") then
-    		vim.api.nvim_clear_autocmds({ group = augroup, buffer = bufnr })
-    		vim.api.nvim_create_autocmd("BufWritePre", {
-    			group = augroup,
-    			buffer = bufnr,
-    			callback = function()
-    				lsp_formatting(bufnr)
-    			end,
-    		})
-    	end
-    end
+    require("null-ls").setup({
+    	sources = {
+    		-- you must download code formatter by yourself!
+    		require("null-ls").builtins.formatting.nixpkgs_fmt,
+    	},
+    	debug = false,
+    	on_attach = function(client, bufnr)
+    		if client.supports_method("textDocument/formatting") then
+    			vim.api.nvim_clear_autocmds({ group = augroup, buffer = bufnr })
+    			vim.api.nvim_create_autocmd("BufWritePost", {
+    				group = augroup,
+    				buffer = bufnr,
+    				callback = function()
+    					async_formatting(bufnr)
+    					lsp_formatting(bufnr)
+    				end,
+    			})
+    		end
+    	end,
+    })
+    ---------------------
+    -- About lspconfig --
+    ---------------------
+    local nvim_lsp = require("lspconfig")
 
     -- Add additional capabilities supported by nvim-cmp
     -- nvim hasn't added foldingRange to default capabilities, users must add it manually
-    local capabilities = vim.lsp.protocol.make_client_capabilities()
+    local capabilities = require("cmp_nvim_lsp").default_capabilities()
+    capabilities = vim.lsp.protocol.make_client_capabilities()
     capabilities.textDocument.foldingRange = {
     	dynamicRegistration = false,
     	lineFoldingOnly = true,
     }
-
-    local nvim_lsp = require("lspconfig")
-
-    nvim_lsp.nixd.setup({
-    	on_attach = on_attach,
-    })
 
     --Change diagnostic symbols in the sign column (gutter)
     local signs = { Error = " ", Warn = " ", Hint = " ", Info = " " }
@@ -281,17 +267,71 @@ let
     	vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = hl })
     end
     vim.diagnostic.config({
-    	-- virtual_text = {
-    	--  source = "always", -- Or "if_many"
-    	-- },
     	virtual_text = false,
     	signs = true,
     	underline = true,
     	update_in_insert = true,
     	severity_sort = false,
-    	float = {
-    		source = "always", -- Or "if_many"
-    	},
+    })
+
+    local on_attach = function(bufnr)
+    	vim.api.nvim_create_autocmd("CursorHold", {
+    		buffer = bufnr,
+    		callback = function()
+    			local opts = {
+    				focusable = false,
+    				close_events = { "BufLeave", "CursorMoved", "InsertEnter", "FocusLost" },
+    				border = "rounded",
+    				source = "always",
+    				prefix = " ",
+    				scope = "line",
+    			}
+    			vim.diagnostic.open_float(nil, opts)
+    		end,
+    	})
+    end
+    nvim_lsp.nixd.setup({
+    	on_attach = on_attach(),
+    	capabilities = capabilities,
+    })
+
+    -- Global mappings.
+    -- See `:help vim.diagnostic.*` for documentation on any of the below functions
+    vim.keymap.set("n", "<space>e", vim.diagnostic.open_float)
+    vim.keymap.set("n", "[d", vim.diagnostic.goto_prev)
+    vim.keymap.set("n", "]d", vim.diagnostic.goto_next)
+    vim.keymap.set("n", "<space>q", vim.diagnostic.setloclist)
+
+    -- Use LspAttach autocommand to only map the following keys
+    -- after the language server attaches to the current buffer
+    vim.api.nvim_create_autocmd("LspAttach", {
+    	group = vim.api.nvim_create_augroup("UserLspConfig", {}),
+    	callback = function(ev)
+    		-- Manual, triggered completion is provided by Nvim's builtin omnifunc. For autocompletion, a general purpose autocompletion plugin(.i.e nvim-cmp) is required
+    		-- Enable completion triggered by <c-x><c-o>
+    		vim.bo[ev.buf].omnifunc = "v:lua.vim.lsp.omnifunc"
+
+    		-- Buffer local mappings.
+    		-- See `:help vim.lsp.*` for documentation on any of the below functions
+    		local opts = { buffer = ev.buf }
+    		vim.keymap.set("n", "gD", vim.lsp.buf.declaration, opts)
+    		vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts)
+    		vim.keymap.set("n", "K", vim.lsp.buf.hover, opts)
+    		vim.keymap.set("n", "gi", vim.lsp.buf.implementation, opts)
+    		vim.keymap.set("n", "<C-k>", vim.lsp.buf.signature_help, opts)
+    		vim.keymap.set("n", "<space>wa", vim.lsp.buf.add_workspace_folder, opts)
+    		vim.keymap.set("n", "<space>wr", vim.lsp.buf.remove_workspace_folder, opts)
+    		vim.keymap.set("n", "<space>wl", function()
+    			print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
+    		end, opts)
+    		vim.keymap.set("n", "<space>D", vim.lsp.buf.type_definition, opts)
+    		vim.keymap.set("n", "<space>rn", vim.lsp.buf.rename, opts)
+    		vim.keymap.set({ "n", "v" }, "<space>ca", vim.lsp.buf.code_action, opts)
+    		vim.keymap.set("n", "gr", vim.lsp.buf.references, opts)
+    		vim.keymap.set("n", "<space>f", function()
+    			vim.lsp.buf.format({ async = true })
+    		end, opts)
+    	end,
     })
   '';
 


### PR DESCRIPTION
When the cursor is moved to the problematic line the diagnostic information will be displayed as a floating window

![image](https://github.com/nix-community/nixd/assets/75824585/635ab002-3c05-4234-9dee-e7caf0d28dc2)
