### PR TITLE
nixd: search "ContainMin" instead of "Start" for completion

### DIFF
--- a/lib/nixd/src/ServerEval.cpp
+++ b/lib/nixd/src/ServerEval.cpp
@@ -272,7 +272,7 @@ void Server::onEvalCompletion(const lspserver::CompletionParams &Params,
       }
     } else {
       try {
-        const auto *Node = AST->lookupStart(Params.position);
+        const auto *Node = AST->lookupContainMin(Params.position);
         if (!Node)
           return;
         const auto *ExprEnv = AST->getEnv(Node);


### PR DESCRIPTION
This will be useful if you are typing `with` expressions.

e.g.

```nix
with foo; [
 #   | <--- Do auto-completion here needs "ExprList", instead of ExprVar.
 #   ^
]
```