### PR TITLE
nixd/documentLink: init

### DIFF
--- a/lib/nixd/include/nixd/AST.h
+++ b/lib/nixd/include/nixd/AST.h
@@ -6,6 +6,7 @@
 
 #include "lspserver/Path.h"
 #include "lspserver/Protocol.h"
+#include "nixd/Position.h"
 
 #include <llvm/ADT/FunctionExtras.h>
 #include <llvm/ADT/StringRef.h>
@@ -21,6 +22,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <utility>
 
@@ -95,6 +97,20 @@ public:
   nix::PosIdx definition(const nix::ExprVar *Var) const {
     return searchDefinition(Var, ParentMap);
   }
+
+  std::optional<lspserver::Range> lRange(const void *Ptr) {
+    try {
+      return toLSPRange(nRange(Ptr));
+    } catch (...) {
+      return std::nullopt;
+    }
+  }
+
+  Range nRange(const void *Ptr) {
+    return {nRangeIdx(Ptr), Data->state.positions};
+  }
+
+  RangeIdx nRangeIdx(const void *Ptr) { return {getPos(Ptr), Data->end}; }
 
   [[nodiscard]] nix::PosIdx getPos(const void *Ptr) {
     return Locations.at(Ptr);

--- a/lib/nixd/include/nixd/JSONSerialization.h
+++ b/lib/nixd/include/nixd/JSONSerialization.h
@@ -28,6 +28,9 @@ bool fromJSON(const llvm::json::Value &Params, MarkupContent &R,
 
 bool fromJSON(const llvm::json::Value &Params, Location &R, llvm::json::Path P);
 
+bool fromJSON(const llvm::json::Value &Params, DocumentLink &R,
+              llvm::json::Path P);
+
 } // namespace lspserver
 
 namespace nixd {

--- a/lib/nixd/include/nixd/Server.h
+++ b/lib/nixd/include/nixd/Server.h
@@ -200,6 +200,10 @@ public:
   void onDefinition(const lspserver::TextDocumentPositionParams &,
                     lspserver::Callback<llvm::json::Value>);
 
+  void
+  onDocumentLink(const lspserver::DocumentLinkParams &,
+                 lspserver::Callback<std::vector<lspserver::DocumentLink>>);
+
   void onHover(const lspserver::TextDocumentPositionParams &,
                lspserver::Callback<lspserver::Hover>);
 
@@ -274,6 +278,10 @@ public:
 
   void onEvalDefinition(const lspserver::TextDocumentPositionParams &,
                         lspserver::Callback<lspserver::Location>);
+
+  void
+  onEvalDocumentLink(const lspserver::TextDocumentIdentifier &,
+                     lspserver::Callback<std::vector<lspserver::DocumentLink>>);
 
   void onEvalHover(const lspserver::TextDocumentPositionParams &,
                    lspserver::Callback<llvm::json::Value>);

--- a/lib/nixd/src/JSONSerialization.cpp
+++ b/lib/nixd/src/JSONSerialization.cpp
@@ -146,4 +146,10 @@ bool fromJSON(const Value &Params, Location &R, llvm::json::Path P) {
   return O && O.map("range", R.range) && O.map("uri", R.uri);
 }
 
+bool fromJSON(const llvm::json::Value &Params, DocumentLink &R,
+              llvm::json::Path P) {
+  ObjectMapper O(Params, P);
+  return O && O.map("range", R.range) && O.map("target", R.target);
+}
+
 } // namespace lspserver

--- a/lib/nixd/src/ServerEval.cpp
+++ b/lib/nixd/src/ServerEval.cpp
@@ -1,3 +1,4 @@
+#include "eval.hh"
 #include "nixd/AST.h"
 #include "nixd/Diagnostic.h"
 #include "nixd/Expr.h"
@@ -210,6 +211,40 @@ void Server::onEvalDefinition(
         }
         RR.Response = error("requested expression is not an ExprVar.");
         return;
+      });
+}
+
+void Server::onEvalDocumentLink(
+    const lspserver::TextDocumentIdentifier &Params,
+    lspserver::Callback<std::vector<lspserver::DocumentLink>> Reply) {
+  using Links = std::vector<lspserver::DocumentLink>;
+  using namespace lspserver;
+  withAST<Links>(
+      Params.uri.file().str(), ReplyRAII<Links>(std::move(Reply)),
+      [Params, File = Params.uri.file().str()](const nix::ref<EvalAST> &AST,
+                                               ReplyRAII<Links> &&RR) {
+        struct LinkFinder : RecursiveASTVisitor<LinkFinder> {
+          decltype(AST) &LinkAST;
+          const std::string &File;
+          Links Result;
+          bool visitExprPath(const nix::ExprPath *EP) {
+            auto Range = LinkAST->lRange(EP);
+            if (Range.has_value()) {
+              try {
+                std::string Path =
+                    nix::resolveExprPath(CanonPath(EP->s)).to_string();
+
+                Result.emplace_back(DocumentLink{
+                    .range = Range.value(),
+                    .target = URIForFile::canonicalize(Path, Path)});
+              } catch (...) {
+              }
+            }
+            return true;
+          }
+        } Finder{.LinkAST = AST, .File = File};
+        Finder.traverseExpr(AST->root());
+        RR.Response = Finder.Result;
       });
 }
 

--- a/tools/nixd/test/initialize.md
+++ b/tools/nixd/test/initialize.md
@@ -35,6 +35,7 @@ CHECK-NEXT:       },
 CHECK-NEXT:       "declarationProvider": true,
 CHECK-NEXT:       "definitionProvider": true,
 CHECK-NEXT:       "documentFormattingProvider": true,
+CHECK-NEXT:       "documentLinkProvider": true,
 CHECK-NEXT:       "hoverProvider": true,
 CHECK-NEXT:       "textDocumentSync": {
 CHECK-NEXT:         "change": 2,


### PR DESCRIPTION
This is currently not testable, because nix will try to lstat the path.

Fixes: #138