### PR TITLE
nixd: override upstream `nix::Value::print` to get shorter message

### DIFF
--- a/lib/nixd/include/nixd/nix/Value.h
+++ b/lib/nixd/include/nixd/nix/Value.h
@@ -12,4 +12,6 @@ bool isDerivation(EvalState &State, Value &V);
 std::optional<std::string> attrPathStr(nix::EvalState &State, nix::Value &V,
                                        const std::string &AttrPath) noexcept;
 
+extern int PrintDepth;
+
 } // namespace nix::nixd

--- a/lib/nixd/src/ServerEval.cpp
+++ b/lib/nixd/src/ServerEval.cpp
@@ -247,6 +247,7 @@ void Server::onEvalHover(const lspserver::TextDocumentPositionParams &Params,
         try {
           auto Value = AST->getValue(Node);
           std::stringstream Res{};
+          nix::nixd::PrintDepth = 3;
           Value.print(IER->Session->getState()->symbols, Res);
           HoverText =
               llvm::formatv("## {0} \n Value: `{1}`", ExprName, Res.str());

--- a/lib/nixd/src/nix/Value.cpp
+++ b/lib/nixd/src/nix/Value.cpp
@@ -1,6 +1,7 @@
 #include "nixd/nix/Value.h"
 
 #include <nix/eval.hh>
+#include <nix/print.hh>
 
 namespace nix::nixd {
 
@@ -37,4 +38,109 @@ std::optional<std::string> attrPathStr(nix::EvalState &State, nix::Value &V,
   return std::nullopt;
 };
 
+int PrintDepth;
+
 } // namespace nix::nixd
+
+namespace nix {
+
+// Use this strong symbol to override nix's implementation
+void Value::print(const SymbolTable &symbols, std::ostream &str,
+                  std::set<const void *> *seen) const {
+  if (nixd::PrintDepth == 0) {
+    str << "{...}";
+    return;
+  }
+
+  struct DepthRAII {
+    decltype(nixd::PrintDepth) &Depth;
+    DepthRAII(decltype(Depth) &D) : Depth(D) { Depth--; }
+    ~DepthRAII() { Depth++; }
+  } _(nixd::PrintDepth);
+
+  // Copy-pasted from upstream:
+
+  switch (internalType) {
+  case tInt:
+    str << integer;
+    break;
+  case tBool:
+    printLiteralBool(str, boolean);
+    break;
+  case tString:
+    printLiteralString(str, string.s);
+    break;
+  case tPath:
+    str << path().to_string(); // !!! escaping?
+    break;
+  case tNull:
+    str << "null";
+    break;
+  case tAttrs: {
+    if (seen && !attrs->empty() && !seen->insert(attrs).second)
+      str << "«repeated»";
+    else {
+      str << "{ ";
+      for (auto &i : attrs->lexicographicOrder(symbols)) {
+        str << symbols[i->name] << " = ";
+        i->value->print(symbols, str, seen);
+        str << "; ";
+      }
+      str << "}";
+    }
+    break;
+  }
+  case tList1:
+  case tList2:
+  case tListN:
+    if (seen && listSize() && !seen->insert(listElems()).second)
+      str << "«repeated»";
+    else {
+      str << "[ ";
+      for (auto v2 : listItems()) {
+        if (v2)
+          v2->print(symbols, str, seen);
+        else
+          str << "(nullptr)";
+        str << " ";
+      }
+      str << "]";
+    }
+    break;
+  case tThunk:
+  case tApp:
+    str << "<CODE>";
+    break;
+  case tLambda:
+    str << "<LAMBDA>";
+    break;
+  case tPrimOp:
+    str << "<PRIMOP>";
+    break;
+  case tPrimOpApp:
+    str << "<PRIMOP-APP>";
+    break;
+  case tExternal:
+    str << *external;
+    break;
+  case tFloat:
+    str << fpoint;
+    break;
+  case tBlackhole:
+    // Although we know for sure that it's going to be an infinite recursion
+    // when this value is accessed _in the current context_, it's likely
+    // that the user will misinterpret a simpler «infinite recursion» output
+    // as a definitive statement about the value, while in fact it may be
+    // a valid value after `builtins.trace` and perhaps some other steps
+    // have completed.
+    str << "«potential infinite recursion»";
+    break;
+  default:
+    printError(
+        "Nix evaluator internal error: Value::print(): invalid value type %1%",
+        internalType);
+    abort();
+  }
+}
+
+} // namespace nix


### PR DESCRIPTION
Large prints make our worker busy and sometimes unnecessary.