### PR TITLE
nixd/eval/definition: support attr goto definition

### DIFF
--- a/nixd/include/nixd/Nix/EvalState.h
+++ b/nixd/include/nixd/Nix/EvalState.h
@@ -6,4 +6,9 @@
 namespace nix {
 /// Similar to nix forceValue, but allow a depth limit
 void forceValueDepth(EvalState &State, Value &v, int depth);
+
+Symbol getName(const AttrName &name, EvalState &state, Env &env);
+
+Value evalAttrPath(EvalState &state, Value Base, Env &env,
+                   const AttrPath &Path);
 } // namespace nix

--- a/nixd/lib/Nix/EvalState.cpp
+++ b/nixd/lib/Nix/EvalState.cpp
@@ -36,4 +36,35 @@ void forceValueDepth(EvalState &State, Value &v, int depth) {
 
   recurse(v, depth);
 }
+
+Symbol getName(const AttrName &Name, EvalState &State, Env &E) {
+  if (Name.symbol) {
+    return Name.symbol;
+  }
+  Value NameValue;
+  Name.expr->eval(State, E, NameValue);
+  State.forceStringNoCtx(NameValue, noPos,
+                         "while evaluating an attribute name");
+  return State.symbols.create(NameValue.string.s);
+}
+
+Value evalAttrPath(EvalState &State, Value Base, Env &E, const AttrPath &Path) {
+  Value *VAttrs = &Base;
+
+  for (const auto &AttrName : Path) {
+    Bindings::iterator It;
+    auto Sym = getName(AttrName, State, E);
+    State.forceAttrs(*VAttrs, noPos, "while selecting an attribute");
+    if ((It = VAttrs->attrs->find(Sym)) == VAttrs->attrs->end()) {
+      State.error("attribute '%1%' missing", State.symbols[Sym])
+          .atPos(noPos)
+          .debugThrow<EvalError>();
+    }
+    VAttrs = It->value;
+  }
+
+  State.forceValue(*VAttrs, noPos);
+  return Base;
+}
+
 } // namespace nix


### PR DESCRIPTION
![goto-attrfield](https://github.com/nix-community/nixd/assets/36667224/4b882783-d1b6-4ece-80d9-b37c5cfd07a9)

Bring you where are the attr fields defined, instead of values.

To address the second point mentioned in https://github.com/nix-community/nixd/issues/173