### PR TITLE
nixd/diagnostic: improve for multiple errors on single file

### DIFF
--- a/lib/nixd/include/nixd/Diagnostic.h
+++ b/lib/nixd/include/nixd/Diagnostic.h
@@ -23,8 +23,15 @@ inline lspserver::Diagnostic mkDiagnosic(const nix::Trace &T,
 std::map<std::string, std::vector<lspserver::Diagnostic>>
 mkDiagnostics(const nix::BaseError &);
 
-void insertDiagnostic(const nix::BaseError &E,
-                      std::vector<lspserver::PublishDiagnosticsParams> &R,
-                      std::optional<uint64_t> Version = std::nullopt);
+void insertDiagnostic(
+    const nix::BaseError &E,
+    std::map<std::string, lspserver::PublishDiagnosticsParams> &R,
+    std::optional<uint64_t> Version = std::nullopt);
 
+inline void
+insertDiagnostic(const nix::ErrorInfo &E,
+                 std::map<std::string, lspserver::PublishDiagnosticsParams> &R,
+                 std::optional<uint64_t> Version = std::nullopt) {
+  return insertDiagnostic(nix::BaseError(E), R, Version);
+}
 } // namespace nixd


### PR DESCRIPTION
Cherry-picks:

    6858a5e (nixd/diagnostic: improve diagnostic for multi-errors, 2023-06-26)

Aiming at providing more diagnostics on a single file, instead of sending it multiple times (LSP client will only show the latest in this case).