### PR TITLE
nixd/parser: make the parser memory-safe

### DIFF
--- a/lib/nixd/include/nixd/nix/ParserEpilogue.cpp
+++ b/lib/nixd/include/nixd/nix/ParserEpilogue.cpp
@@ -4,10 +4,13 @@
 
 #include "Lexer.tab.h"
 
+#include "nixd/Expr.h"
+
 #include <nix/eval.hh>
 #include <nix/fetchers.hh>
 #include <nix/filetransfer.hh>
 #include <nix/flake/flake.hh>
+#include <nix/nixexpr.hh>
 #include <nix/store-api.hh>
 
 #include <fcntl.h>
@@ -39,4 +42,45 @@ std::unique_ptr<ParseData> parse(char *text, size_t length, Pos::Origin origin,
 
   return data; // NRVO
 }
+
+void tryFree(auto *&Ptr, std::set<void *> &Freed) {
+  if (Freed.contains(Ptr))
+    return;
+
+  delete Ptr;
+  Freed.insert(Ptr);
+  Ptr = nullptr;
+}
+
+void destroyAST(auto *&Root, std::set<void *> &Freed) {
+  if (Freed.contains(Root))
+    return;
+#define TRY_TO_TRAVERSE(CHILD)                                                 \
+  do {                                                                         \
+    destroyAST(CHILD, Freed);                                                  \
+    (CHILD) = nullptr;                                                         \
+  } while (false)
+
+#define DEF_TRAVERSE_TYPE(TYPE, CODE)                                          \
+  if (auto *T = dynamic_cast<nix::TYPE *>(Root)) {                             \
+    { CODE; }                                                                  \
+  }
+#include "nixd/NixASTTraverse.inc"
+#undef TRY_TO_TRAVERSE
+#undef DEF_TRAVERSE_TYPE
+  if (auto *E = dynamic_cast<nix::ExprConcatStrings *>(Root)) {
+    tryFree(E->es, Freed);
+  }
+  if (auto *E = dynamic_cast<nix::ExprLambda *>(Root)) {
+    tryFree(E->formals, Freed);
+  }
+  tryFree(Root, Freed);
+}
+
+ParseData::~ParseData() {
+  // Destroy AST nodes;
+  std::set<void *> Freed;
+  destroyAST(result, Freed);
+}
+
 } // namespace nixd

--- a/lib/nixd/include/nixd/nix/ParserPrologue.h
+++ b/lib/nixd/include/nixd/nix/ParserPrologue.h
@@ -219,9 +219,12 @@ static Expr *stripIndentation(
   }
 
   /* If this is a single string, then don't do a concatenation. */
-  return es2->size() == 1 && dynamic_cast<ExprString *>((*es2)[0].second)
-             ? (*es2)[0].second
-             : new ExprConcatStrings(pos, true, es2);
+  if (es2->size() == 1 && dynamic_cast<ExprString *>((*es2)[0].second)) {
+    auto *const result = (*es2)[0].second;
+    delete es2;
+    return result;
+  }
+  return new ExprConcatStrings(pos, true, es2);
 }
 
 } // namespace nixd

--- a/lib/nixd/include/nixd/nix/ParserRequire.h
+++ b/lib/nixd/include/nixd/nix/ParserRequire.h
@@ -24,6 +24,7 @@ struct ParseData {
   std::vector<ErrorInfo> error;
   std::map<PosIdx, PosIdx> end;
   std::map<const void *, PosIdx> locations;
+  ~ParseData();
 };
 
 struct ParserFormals {


### PR DESCRIPTION
Tested on many large workloads:

```
❯ valgrind --leak-check=full build/nixd-ast-dump ../nixpkgs/lib/deprecated.nix
==4119151== Memcheck, a memory error detector
==4119151== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==4119151== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==4119151== Command: build/nixd-ast-dump ../nixpkgs/lib/deprecated.nix
==4119151==
==4119151==
==4119151== HEAP SUMMARY:
==4119151==     in use at exit: 159,477 bytes in 2,313 blocks
==4119151==   total heap usage: 18,151 allocs, 15,838 frees, 1,558,447 bytes allocated
==4119151==
==4119151== LEAK SUMMARY:
==4119151==    definitely lost: 0 bytes in 0 blocks
==4119151==    indirectly lost: 0 bytes in 0 blocks
==4119151==      possibly lost: 0 bytes in 0 blocks
==4119151==    still reachable: 159,477 bytes in 2,313 blocks
==4119151==         suppressed: 0 bytes in 0 blocks
==4119151== Reachable blocks (those to which a pointer was found) are not shown.
==4119151== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==4119151==
==4119151== For lists of detected and suppressed errors, rerun with: -s
==4119151== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
❯ valgrind --leak-check=full build/nixd-ast-dump ../nixpkgs/pkgs/top-level/all-packages.nix
==4119447== Memcheck, a memory error detector
==4119447== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==4119447== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==4119447== Command: build/nixd-ast-dump ../nixpkgs/pkgs/top-level/all-packages.nix
==4119447==
==4119447==
==4119447== HEAP SUMMARY:
==4119447==     in use at exit: 159,477 bytes in 2,313 blocks
==4119447==   total heap usage: 740,483 allocs, 738,170 frees, 45,180,187 bytes allocated
==4119447==
==4119447== LEAK SUMMARY:
==4119447==    definitely lost: 0 bytes in 0 blocks
==4119447==    indirectly lost: 0 bytes in 0 blocks
==4119447==      possibly lost: 0 bytes in 0 blocks
==4119447==    still reachable: 159,477 bytes in 2,313 blocks
==4119447==         suppressed: 0 bytes in 0 blocks
==4119447== Reachable blocks (those to which a pointer was found) are not shown.
==4119447== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==4119447==
==4119447== For lists of detected and suppressed errors, rerun with: -s
==4119447== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
❯ valgrind --leak-check=full build/nixd-ast-dump ../nixpkgs/pkgs/top-level/linux-kernels.nix
==4123426== Memcheck, a memory error detector
==4123426== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==4123426== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==4123426== Command: build/nixd-ast-dump ../nixpkgs/pkgs/top-level/linux-kernels.nix
==4123426==
==4123426==
==4123426== HEAP SUMMARY:
==4123426==     in use at exit: 159,477 bytes in 2,313 blocks
==4123426==   total heap usage: 24,524 allocs, 22,211 frees, 1,979,203 bytes allocated
==4123426==
==4123426== LEAK SUMMARY:
==4123426==    definitely lost: 0 bytes in 0 blocks
==4123426==    indirectly lost: 0 bytes in 0 blocks
==4123426==      possibly lost: 0 bytes in 0 blocks
==4123426==    still reachable: 159,477 bytes in 2,313 blocks
==4123426==         suppressed: 0 bytes in 0 blocks
==4123426== Reachable blocks (those to which a pointer was found) are not shown.
==4123426== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==4123426==
==4123426== For lists of detected and suppressed errors, rerun with: -s
==4123426== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
❯ valgrind --leak-check=full build/nixd-ast-dump ../nixpkgs/lib/modules.nix
==4123695== Memcheck, a memory error detector
==4123695== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==4123695== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==4123695== Command: build/nixd-ast-dump ../nixpkgs/lib/modules.nix
==4123695==
==4123695==
==4123695== HEAP SUMMARY:
==4123695==     in use at exit: 159,477 bytes in 2,313 blocks
==4123695==   total heap usage: 30,115 allocs, 27,802 frees, 2,276,066 bytes allocated
==4123695==
==4123695== LEAK SUMMARY:
==4123695==    definitely lost: 0 bytes in 0 blocks
==4123695==    indirectly lost: 0 bytes in 0 blocks
==4123695==      possibly lost: 0 bytes in 0 blocks
==4123695==    still reachable: 159,477 bytes in 2,313 blocks
==4123695==         suppressed: 0 bytes in 0 blocks
==4123695== Reachable blocks (those to which a pointer was found) are not shown.
==4123695== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==4123695==
==4123695== For lists of detected and suppressed errors, rerun with: -s
==4123695== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```