### PR TITLE
nixd: kill child on linux

### DIFF
--- a/nixd/tools/nixd/nixd.cpp
+++ b/nixd/tools/nixd/nixd.cpp
@@ -27,6 +27,10 @@
 #include <csignal>
 #include <unistd.h>
 
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
+
 using lspserver::JSONStreamStyle;
 using lspserver::Logger;
 
@@ -99,6 +103,9 @@ opt<bool> WaitWorker{"wait-worker",
 
 int main(int argc, char *argv[]) {
   using namespace lspserver;
+#ifdef __linux__
+  prctl(PR_SET_PDEATHSIG, SIGHUP);
+#endif
   nixd::registerSigHanlder();
   const char *FlagsEnvVar = "NIXD_FLAGS";
   HideUnrelatedOptions(NixdCatogories);


### PR DESCRIPTION
Use the system call prctl to inform OS killing all forked processes after the parent died.