### PR TITLE
nixd/Server: fix outdated draft version for static analysis

### DIFF
--- a/nixd/include/nixd/Server/ASTManager.h
+++ b/nixd/include/nixd/Server/ASTManager.h
@@ -39,7 +39,7 @@ public:
 
   /// Store the action in a local structure, the action will be invoked when the
   /// task finished.
-  void withAST(const std::string &Path, ActionTy Action);
+  void withAST(const std::string &Path, VersionTy Version, ActionTy Action);
 
   void schedParse(const std::string &Content, const std::string &Path,
                   VersionTy Version);

--- a/nixd/lib/Server/ASTManager.cpp
+++ b/nixd/lib/Server/ASTManager.cpp
@@ -7,12 +7,13 @@
 
 namespace nixd {
 
-void ASTManager::withAST(const std::string &Path, ActionTy Action) {
+void ASTManager::withAST(const std::string &Path, VersionTy Version,
+                         ActionTy Action) {
   {
     std::lock_guard _(ActionsLock);
     Actions.insert({Path, std::move(Action)});
   }
-  checkCacheAndInvoke(Path, 0);
+  checkCacheAndInvoke(Path, Version);
 }
 
 void ASTManager::invokeActions(const ParseAST &AST, const std::string &Path,

--- a/nixd/lib/Server/Controller.cpp
+++ b/nixd/lib/Server/Controller.cpp
@@ -512,8 +512,12 @@ void Server::onCompletion(
           Resp.emplace_back(CompletionList{false, Items});
           Smp.release();
         };
-        ASTMgr.withAST(Path.str(), std::move(Action));
-        Smp.acquire();
+        if (auto Draft = DraftMgr.getDraft(Path)) {
+          auto Version =
+              EvalDraftStore::decodeVersion(Draft->Version).value_or(0);
+          ASTMgr.withAST(Path.str(), Version, std::move(Action));
+          Smp.acquire();
+        }
       } catch (std::exception &E) {
         lspserver::elog("completion/parseAST: {0}", stripANSI(E.what()));
       } catch (...) {


### PR DESCRIPTION
Fixes the error found in the CI:

    https://github.com/nix-community/nixd/actions/runs/5474230815

If the new version haven't been evaluated, but enqueued, wait for the new version, do not process the old one.