### PR TITLE
build derivation: move lit to buildInputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,12 +31,12 @@ stdenv.mkDerivation {
   ];
 
   nativeCheckInputs = [
-    lit
     nixpkgs-fmt
   ];
 
   buildInputs = [
     libbacktrace
+    lit
     nix
     gtest
     boost182


### PR DESCRIPTION
lit is necessary for buildPhase, not just checkPhase

found while working around #215