### PR TITLE
nixd/Sema: add some nixd::Expr node lowering

### DIFF
--- a/nixd/include/nixd/Sema/Lowering.h
+++ b/nixd/include/nixd/Sema/Lowering.h
@@ -60,6 +60,8 @@ struct Lowering {
   nix::ExprLambda *lowerFunction(const syntax::Function *Fn);
   nix::Formal lowerFormal(const syntax::Formal &Formal);
   nix::AttrPath lowerAttrPath(const syntax::AttrPath &Path);
+  nix::Expr *lowerOp(const syntax::Node *Op);
+  nix::ExprCall *lowerBinaryOp(const const std::string &FnName);
 };
 
 } // namespace nixd

--- a/nixd/lib/Sema/Lowering.cpp
+++ b/nixd/lib/Sema/Lowering.cpp
@@ -436,6 +436,15 @@ nix::Expr *Lowering::lower(const syntax::Node *Root) {
     auto *Ret = new nix::ExprLet(Attrs, Body);
     return Ret;
   }
+  case Node::NK_If: {
+    const auto *If = dynamic_cast<const syntax::If *>(Root);
+    auto *Cond = lower(If->Cond);
+    auto *Then = lower(If->Then);
+    auto *Else = lower(If->Else);
+    auto *NixIf =
+        Ctx.Pool.record(new nix::ExprIf(If->Range.Begin, Cond, Then, Else));
+    return NixIf;
+  }
   }
 
   return nullptr;


### PR DESCRIPTION
try implement some nix::Expr node lowering, want to be reviewed.
I suggest rewrite `enum NodeKind`, add `NK_EXPROP` for all op type syntax, this may need change define file.
besides, operator position will not get under current design, like`TODO` in code, can simply ignore?