### PR TITLE
nixd/Server/configuration: Log when `workspace/configuration` is `[null]`

### DIFF
--- a/nixd/lib/Server/Controller.cpp
+++ b/nixd/lib/Server/Controller.cpp
@@ -207,7 +207,7 @@ void Controller::fetchConfig() {
                 lspserver::ConfigurationItem{.section = "nixd"}}},
         [this](llvm::Expected<OptionalValue> Response) {
           if (Response) {
-            const llvm::json::Value ResponseValue =
+            const llvm::json::Value &ResponseValue =
                 Response.get().Value.value();
             if (ResponseValue.kind() != llvm::json::Value::Array) {
               lspserver::elog(
@@ -215,7 +215,7 @@ void Controller::fetchConfig() {
                   ResponseValue);
               return;
             }
-            const llvm::json::Value FirstConfig =
+            const llvm::json::Value &FirstConfig =
                 ResponseValue.getAsArray()->front();
             if (FirstConfig.kind() == llvm::json::Value::Null) {
               lspserver::log("workspace/configuration is not set");

--- a/nixd/lib/Server/Controller.cpp
+++ b/nixd/lib/Server/Controller.cpp
@@ -207,8 +207,16 @@ void Controller::fetchConfig() {
                 lspserver::ConfigurationItem{.section = "nixd"}}},
         [this](llvm::Expected<OptionalValue> Response) {
           if (Response) {
+            const llvm::json::Value ResponseValue =
+                Response.get().Value.value();
+            if (ResponseValue.kind() != llvm::json::Value::Array) {
+              lspserver::elog(
+                  "workspace/configuration response is not an array: {0}",
+                  ResponseValue);
+              return;
+            }
             const llvm::json::Value FirstConfig =
-                Response.get().Value.value().getAsArray()->front();
+                ResponseValue.getAsArray()->front();
             if (FirstConfig.kind() == llvm::json::Value::Null) {
               lspserver::log("workspace/configuration is not set");
               return;

--- a/nixd/lib/Server/Controller.cpp
+++ b/nixd/lib/Server/Controller.cpp
@@ -207,10 +207,16 @@ void Controller::fetchConfig() {
                 lspserver::ConfigurationItem{.section = "nixd"}}},
         [this](llvm::Expected<OptionalValue> Response) {
           if (Response) {
+            const llvm::json::Value FirstConfig =
+                Response.get().Value.value().getAsArray()->front();
+            if (FirstConfig.kind() == llvm::json::Value::Null) {
+              lspserver::log("workspace/configuration is not set");
+              return;
+            }
             llvm::Expected<configuration::TopLevel> ResponseConfig =
                 lspserver::parseParamWithDefault<configuration::TopLevel>(
-                    Response.get().Value.value(), "workspace/configuration",
-                    "reply", DefaultConfig);
+                    FirstConfig, "workspace/configuration", "reply",
+                    DefaultConfig);
             if (ResponseConfig) {
               updateConfig(std::move(ResponseConfig.get()));
             }


### PR DESCRIPTION
Previously, when `workspace/configuration` was unset, we would get `[null]`, causing an error to be raised by LLVM. While this error is harmless, it causes confusion (it is mentioned in #266, for example). This PR replaces the error message with a log that mentions `workspace/configuration` is unset. This should be more informative for users using `.nixd.json` instead of `workspace/configuration` to configure nixd.