### PR TITLE
docs/editor-setup: add Emacs setup information

### DIFF
--- a/docs/editor-setup.md
+++ b/docs/editor-setup.md
@@ -36,3 +36,18 @@ According to `:help coc-config.txt`, `coc-settings.json`:
 
 Neovim native LSP and [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig).
 We are officially supported by nvim-lspconfig, see [upstream docs](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.txt#nixd)
+
+### Emacs
+
+[This PR](https://github.com/emacs-lsp/lsp-mode/pull/4125) should add nixd support to [LSP Mode](https://github.com/emacs-lsp/lsp-mode).
+
+A simple Emacs Lisp configuration that adds nixd to LSP Mode in the mean time is as follows:
+
+```lisp
+(with-eval-after-load 'lsp-mode
+  (lsp-register-client
+    (make-lsp-client :new-connection (lsp-stdio-connection "nixd")
+                     :major-modes '(nix-mode)
+                     :priority 0
+                     :server-id 'nixd)))
+```


### PR DESCRIPTION
Adds a section to [editor-setup.md](https://github.com/nix-community/nixd/blob/main/docs/editor-setup.md) that adds guidance on making nixd work with Emacs. When https://github.com/emacs-lsp/lsp-mode/pull/4125 (or another PR that adds nixd) is merged, this section should be changed.