### PR TITLE
libnixt: add Serialize

### DIFF
--- a/libnixt/include/nixt/ArrayRef.h
+++ b/libnixt/include/nixt/ArrayRef.h
@@ -1,0 +1,35 @@
+/// \file
+/// \brief `ArrayRef`, `BytesRef`, and related functions.
+#pragma once
+
+#include <string_view>
+
+namespace nixt {
+
+/// \brief Weak reference to an array, with begin and end pointers.
+/// \note Please always pass/return by value and don't add member functions.
+template <class T> struct ArrayRef {
+  const T *Begin;
+  const T *End;
+};
+
+using BytesRef = ArrayRef<char>;
+
+/// \brief Iterator begin. Used for `range-based-for`
+template <class T> inline const T *begin(ArrayRef<T> B) { return B.Begin; }
+
+/// \brief Iterator end.
+template <class T> inline const T *end(ArrayRef<T> B) { return B.End; }
+
+inline std::string_view view(BytesRef B) { return {B.Begin, B.End}; }
+
+/// \brief Advance the beginning pointer of bytes array.
+template <class T> inline ArrayRef<T> advance(ArrayRef<T> B, long Offset) {
+  return {B.Begin + Offset, B.End};
+}
+/// \brief Get length of this array.
+template <class T> inline std::size_t lengthof(ArrayRef<T> B) {
+  return B.End - B.Begin;
+}
+
+} // namespace nixt

--- a/libnixt/include/nixt/PtrPool.h
+++ b/libnixt/include/nixt/PtrPool.h
@@ -1,0 +1,41 @@
+/// \file
+/// \brief Pointer pool, for RAII memory management.
+
+// TODO: This file is trivial and shared among many libraries, maybe should move
+// this in a standalone public header.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+namespace nixt {
+
+/// \brief A simple pointer pool, a vector of `unique_ptr`s.
+///
+/// It is used for "owning" nodes. Other classes can use weak/raw pointers to
+/// the nodes, to  avoid cyclic references.
+///
+/// Also in nix AST, the nodes are not owned by it's parent because in bison
+/// algorithm nodes should be copyable while performing shift-reduce. So in our
+/// implementation nodes are owned in this structure.
+template <class T> struct PtrPool {
+  std::vector<std::unique_ptr<T>> Nodes;
+
+  /// \brief Takes ownership of a node, add it to the pool.
+  template <class U> U *add(std::unique_ptr<U> Node) {
+    Nodes.push_back(std::move(Node));
+    return dynamic_cast<U *>(Nodes.back().get());
+  }
+
+  /// \brief Takes ownership from a raw pointer.
+  ///
+  /// \note This should only be used when it is allocated by "malloc", and not
+  /// owned by other objects (otherwise it will cause double free).
+  template <class U> U *record(U *Node) {
+    Nodes.emplace_back(std::unique_ptr<U>(Node));
+    return Node;
+  }
+};
+
+} // namespace nixt

--- a/libnixt/include/nixt/Serialize.h
+++ b/libnixt/include/nixt/Serialize.h
@@ -1,0 +1,104 @@
+/// \file
+/// \brief Serialize nix::Expr to bytes & deserialize from bytes.
+
+#pragma once
+
+#include "nixt/ArrayRef.h"
+#include "nixt/PtrPool.h"
+
+#include <nix/nixexpr.hh>
+
+namespace nixt::serialize {
+
+//===----------------------------------------------------------------------===//
+// Shared type definitions & constants
+//===----------------------------------------------------------------------===//
+
+enum class EncodeKind : uint32_t {
+#define NIX_EXPR(EXPR) EXPR,
+#include "Nodes.inc"
+#undef NIX_EXPR
+
+  // Special discriminator for nix::AttrName.
+  // struct AttrName
+  // {
+  //     Symbol symbol;
+  //     Expr * expr;
+  //     AttrName(Symbol s) : symbol(s) {};
+  //     AttrName(Expr * e) : expr(e) {};
+  // };
+  AttrNameSymbol,
+};
+
+using nix::NixFloat;
+using nix::NixInt;
+
+// Checking for actual type, for ABI compability during nix updates.
+// Because nix language is currently very "stable", this should not easily
+// broken.
+static_assert(std::is_same_v<nix::NixFloat, double>);
+static_assert(std::is_same_v<nix::NixInt, std::int64_t>);
+
+using PosInt = decltype(nix::Pos::line);
+static_assert(std::is_same_v<PosInt, decltype(nix::Pos::column)>);
+static_assert(std::is_same_v<PosInt, uint32_t>); // check for ABI breakage.
+
+/// \brief Header of serialized AST.
+struct ASTHeader {
+  char Magic[8];
+  uint32_t Version;
+};
+
+//===----------------------------------------------------------------------===//
+// Encoder
+//===----------------------------------------------------------------------===//
+
+/// \brief Basic primitives. Trivial data types are just written to a stream.
+/// \returns The beginning offset of the data in the stream.
+template <class T>
+  requires std::is_standard_layout_v<T> && std::is_trivial_v<T>
+std::size_t encode(std::ostream &OS, const T &Data) {
+  std::size_t Ret = OS.tellp();
+  OS.write(reinterpret_cast<const char *>(&Data), sizeof(Data));
+  return Ret;
+}
+
+/// \brief Encode string to bytes.
+std::size_t encode(std::ostream &OS, const std::string &Data);
+
+/// \brief Encode string to bytes.
+std::size_t encode(std::ostream &OS, const nix::Pos::Origin &Origin);
+
+/// \brief Encode an AST. \p E is the root of the AST.
+void encodeAST(std::ostream &OS, const nix::SymbolTable &STable,
+               const nix::PosTable &PTable, const nix::Pos::Origin &Origin,
+               const nix::Expr *E);
+
+//===----------------------------------------------------------------------===//
+// Decoder
+//===----------------------------------------------------------------------===//
+
+/// \brief Basic primitives. Deocde from bytes by `memcpy`.
+/// \returns Size of bytes consumed.
+template <class T>
+  requires std::is_standard_layout_v<T> && std::is_trivial_v<T>
+std::size_t decode(BytesRef Data, T &Obj) {
+  assert(lengthof(Data) >= sizeof(T));
+  std::memcpy(&Obj, begin(Data), sizeof(T));
+  return sizeof(T);
+}
+
+/// \brief Decode string from bytes.
+std::size_t decode(BytesRef Data, std::string &Str);
+
+/// \brief Consume bytes from \p Data and construct an object of type \p T.
+template <class T> T consume(BytesRef &Data) {
+  T Obj;
+  Data = advance(Data, decode(Data, Obj));
+  return Obj;
+}
+
+nix::Expr *consumeAST(BytesRef &Data, PtrPool<nix::Expr> &Pool,
+                      nix::PosTable &PTable, nix::SymbolTable &STable);
+
+} // namespace nixt::serialize

--- a/libnixt/lib/Deserialize.cpp
+++ b/libnixt/lib/Deserialize.cpp
@@ -1,0 +1,134 @@
+#include "nixt/ArrayRef.h"
+#include "nixt/Serialize.h"
+
+namespace nixt::serialize {
+namespace {
+
+class ASTDecoder {
+  PtrPool<nix::Expr> &Pool;
+  const char *Begin;
+  BytesRef Cur;
+  nix::PosTable &PTable;
+  nix::SymbolTable &STable;
+  const nix::Pos::Origin &Origin;
+  std::map<std::size_t, const nix::Expr *> ExprMap;
+
+  template <typename T> T eat() { return consume<T>(Cur); }
+
+  [[nodiscard]] std::size_t offset() const { return Cur.Begin - Begin; }
+
+  template <typename T, typename... ArgTs> T *create(ArgTs &&...Args) {
+    auto Ptr = Pool.record(new T(std::forward<ArgTs>(Args)...));
+    ExprMap[offset()] = Ptr;
+    return Ptr;
+  }
+
+  nix::PosIdx decodePosIdx() {
+    auto Line = eat<PosInt>();
+    if (Line == PosInt(-1))
+      return nix::noPos;
+
+    auto Column = eat<PosInt>();
+    return PTable.add(Origin, Line, Column);
+  }
+
+  nix::Symbol decodeSymbol() { return STable.create(eat<std::string>()); }
+
+  nix::ExprInt *decodeExprInt() {
+    return create<nix::ExprInt>(eat<nix::NixInt>());
+  }
+
+  nix::ExprFloat *decodeExprFloat() {
+    return create<nix::ExprFloat>(eat<nix::NixFloat>());
+  }
+
+  nix::ExprString *decodeExprString() {
+    return create<nix::ExprString>(eat<std::string>());
+  }
+
+  nix::ExprPath *decodeExprPath() {
+    return create<nix::ExprPath>(eat<nix::Path>());
+  }
+
+  nix::ExprVar *decodeExprVar() {
+    auto Pos = decodePosIdx();
+    auto Name = decodeSymbol();
+    nix::ExprVar E(Pos, Name);
+    E.fromWith = eat<bool>();
+    E.level = eat<nix::Level>();
+    E.displ = eat<nix::Displacement>();
+
+    return create<nix::ExprVar>(std::move(E));
+  }
+
+public:
+  ASTDecoder(PtrPool<nix::Expr> &Pool, BytesRef Data, nix::PosTable &PTable,
+             nix::SymbolTable &STable, const nix::Pos::Origin &Origin)
+      : Pool(Pool), Begin(Data.Begin), Cur(Data), PTable(PTable),
+        STable(STable), Origin(Origin) {}
+
+  nix::Expr *decodeExpr() {
+    const auto Kind = eat<EncodeKind>();
+    switch (Kind) {
+    case EncodeKind::ExprInt:
+      return decodeExprInt();
+    case EncodeKind::ExprFloat:
+      return decodeExprFloat();
+    case EncodeKind::ExprString:
+      return decodeExprString();
+    case EncodeKind::ExprPath:
+      return decodeExprPath();
+    case EncodeKind::ExprVar:
+      return decodeExprVar();
+    default:
+      assert(false && "Unknown kind");
+      break;
+    }
+  }
+
+  [[nodiscard]] BytesRef getBytesRef() const { return Cur; }
+};
+
+} // namespace
+
+std::size_t decode(BytesRef Data, std::string &Str) {
+  assert(lengthof(Data) >= sizeof(std::size_t));
+  std::size_t Length;
+  decode(Data, Length);
+  const char *Begin = Data.Begin + sizeof(std::size_t);
+  Str = std::string(Begin, Length);
+  return sizeof(std::size_t) + Length;
+}
+
+template <> nix::Pos::Origin consume<nix::Pos::Origin>(BytesRef &Data) {
+  auto Index = consume<std::size_t>(Data);
+  switch (Index) {
+  case 0:
+    return nix::Pos::none_tag{};
+    break;
+  case 1:
+  case 2:
+    return nix::Pos::Stdin{nix::make_ref<std::string>("")};
+    break;
+  case 3:
+    return nix::CanonPath(consume<std::string>(Data));
+    break;
+  default:
+    assert(false && "Unknown origin");
+    break;
+  }
+}
+
+nix::Expr *consumeAST(BytesRef &Data, PtrPool<nix::Expr> &Pool,
+                      nix::PosTable &PTable, nix::SymbolTable &STable) {
+  auto Header = consume<ASTHeader>(Data);
+  assert(std::memcmp(Header.Magic, "\x7FNixAST\0", 8) == 0);
+  assert(Header.Version == 1);
+  auto Origin = consume<nix::Pos::Origin>(Data);
+  ASTDecoder Decoder(Pool, Data, PTable, STable, Origin);
+  nix::Expr *E = Decoder.decodeExpr();
+  Data = Decoder.getBytesRef();
+  return E;
+}
+
+} // namespace nixt::serialize

--- a/libnixt/lib/Serialize.cpp
+++ b/libnixt/lib/Serialize.cpp
@@ -1,0 +1,143 @@
+#include "nixt/Serialize.h"
+#include "nixt/Kinds.h"
+
+namespace nixt::serialize {
+
+namespace {
+
+class ASTEncoder {
+  std::ostream &OS;
+  const nix::SymbolTable &STable;
+  const nix::PosTable &PTable;
+  std::map<const nix::Expr *, std::size_t> ExprMap;
+
+  void encodePosIdx(nix::PosIdx P) {
+    // Special case for nix::noPos.
+    if (P == nix::noPos) {
+      encode(OS, PosInt(-1));
+      return;
+    }
+
+    // Only line + column will be written to the stream, without "Origin".
+    // Because Origins are too big and actually a single nix file has a unique
+    // origin.
+    const auto &Pos = PTable[P];
+    encode(OS, Pos.line);
+    encode(OS, Pos.column);
+  }
+
+  void encodeSymbol(const nix::Symbol &S) {
+    encode(OS, std::string(STable[S]));
+  }
+
+  void encodeExprInt(const nix::ExprInt *E) {
+    assert(E);
+    ExprMap[E] = encode(OS, EncodeKind::ExprInt);
+    encode(OS, E->n);
+  }
+
+  void encodeExprFloat(const nix::ExprFloat *E) {
+    assert(E);
+    ExprMap[E] = encode(OS, EncodeKind::ExprFloat);
+    encode(OS, E->nf);
+  }
+
+  void encodeExprString(const nix::ExprString *E) {
+    assert(E);
+    ExprMap[E] = encode(OS, EncodeKind::ExprString);
+    encode(OS, E->s);
+  }
+
+  void encodeExprPath(const nix::ExprPath *E) {
+    assert(E);
+    ExprMap[E] = encode(OS, EncodeKind::ExprPath);
+    encode(OS, E->s);
+  }
+
+  void encodeExprVar(const nix::ExprVar *E) {
+    assert(E);
+    ExprMap[E] = encode(OS, EncodeKind::ExprVar);
+    encodePosIdx(E->pos);
+    encodeSymbol(E->name);
+    encode(OS, E->fromWith);
+    encode(OS, E->level);
+    encode(OS, E->displ);
+  }
+
+public:
+  ASTEncoder(std::ostream &OS, const nix::SymbolTable &STable,
+             const nix::PosTable &PTable)
+      : OS(OS), STable(STable), PTable(PTable) {
+    ExprMap[nullptr] = 0;
+  }
+
+  void encodeExpr(const nix::Expr *E) {
+    using namespace ek;
+    if (!E)
+      return;
+    switch (kindOf(*E)) {
+    case EK_ExprInt:
+      encodeExprInt(static_cast<const nix::ExprInt *>(E));
+      break;
+    case EK_ExprFloat:
+      encodeExprFloat(static_cast<const nix::ExprFloat *>(E));
+      break;
+    case EK_ExprString:
+      encodeExprString(static_cast<const nix::ExprString *>(E));
+      break;
+    case EK_ExprPath:
+      encodeExprPath(static_cast<const nix::ExprPath *>(E));
+      break;
+    case EK_ExprVar:
+      encodeExprVar(static_cast<const nix::ExprVar *>(E));
+      break;
+    default:
+      assert(false && "Not supported yet!");
+      break;
+    }
+  };
+};
+
+} // namespace
+
+std::size_t encode(std::ostream &OS, const std::string &Data) {
+  // Firstly write the size of the string, because std::string may contain \0
+  std::size_t Ret = encode(OS, Data.size());
+  OS.write(Data.c_str(), static_cast<long>(Data.size()));
+  return Ret;
+}
+
+std::size_t encode(std::ostream &OS, const nix::Pos::Origin &Origin) {
+  std::size_t Ret = encode(OS, Origin.index());
+  switch (Origin.index()) {
+  case 0: // none_tag
+  case 1: // Stdin (may break nix)
+  case 2: // String (may break nix)
+    break;
+  case 3: // SourcePath
+    encode(OS, std::get<3>(Origin).to_string());
+    break;
+  default:
+    assert(false && "unreachable");
+    break;
+  }
+
+  return Ret;
+}
+
+void encodeAST(std::ostream &OS, const nix::SymbolTable &STable,
+               const nix::PosTable &PTable, const nix::Pos::Origin &Origin,
+               const nix::Expr *E) {
+  // Write the header, metadata stuff like a magic number and a version number.
+  ASTHeader Header;
+  strcpy(Header.Magic, "\x7fNixAST");
+  Header.Version = 1;
+  encode(OS, Header);
+
+  encode(OS, Origin);
+
+  ASTEncoder Encoder(OS, STable, PTable);
+  Encoder.encodeExpr(E);
+}
+
+} // namespace nixt::serialize

--- a/libnixt/meson.build
+++ b/libnixt/meson.build
@@ -7,9 +7,11 @@ libnixtDeps = [ nix_expr, nix_main, nix_cmd, boost ]
 libnixdInc = include_directories('include')
 
 libnixt = library('nixt',
+                  'lib/Deserialize.cpp',
                   'lib/Displacement.cpp',
                   'lib/Kinds.cpp',
                   'lib/ParentMap.cpp',
+                  'lib/Serialize.cpp',
                   include_directories: libnixdInc,
                   dependencies: libnixtDeps,
                   install: true
@@ -29,7 +31,9 @@ nixt = declare_dependency(include_directories: libnixdInc,
 )
 
 libnixt_test_exe = executable('test-libnixt',
+                              'test/Deserialize.cpp',
                               'test/Kinds.cpp',
+                              'test/Serialize.cpp',
                               dependencies: [ gtest_main, nixt ])
 
 test('unit/libnixt', libnixt_test_exe)

--- a/libnixt/test/Deserialize.cpp
+++ b/libnixt/test/Deserialize.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include "nixt/ArrayRef.h"
+#include "nixt/PtrPool.h"
+#include "nixt/Serialize.h"
+
+using namespace nixt::serialize;
+using namespace nixt;
+using namespace std::literals;
+
+namespace {
+
+class DeserializeTest : public testing::Test {
+protected:
+  nix::PosTable PT;
+  nix::SymbolTable ST;
+  std::ostringstream OS;
+  std::string Result;
+  PtrPool<nix::Expr> Pool;
+
+  BytesRef encode(const nix::Expr *E) {
+    nixt::serialize::encodeAST(OS, ST, PT, nix::Pos::none_tag{}, E);
+    Result = OS.str();
+    return {Result.data(), Result.data() + Result.size()};
+  }
+  nix::PosIdx somePos() {
+    nix::Pos::Origin O = nix::Pos::none_tag{};
+    return PT.add(O, 32, 32);
+  }
+  nix::AttrName someAttrNameSymbol() { return {ST.create("hello")}; }
+  static nix::AttrName someAttrNameExpr() { return nullptr; }
+};
+
+std::unique_ptr<nix::ExprInt> mkInt(nix::NixInt N) {
+  return std::make_unique<nix::ExprInt>(N);
+}
+
+template <class T> void check(BytesRef &Data, T Expected) {
+  EXPECT_EQ(consume<T>(Data), Expected);
+}
+
+void checkEmpty(BytesRef &Data) { EXPECT_EQ(lengthof(Data), 0); }
+
+TEST_F(DeserializeTest, ExprInt) {
+  auto Data = encode(mkInt(0xdeadbeef).get());
+  auto *E = consumeAST(Data, Pool, PT, ST);
+  EXPECT_EQ(static_cast<nix::ExprInt *>(E)->n, 0xdeadbeef);
+  checkEmpty(Data);
+}
+
+TEST_F(DeserializeTest, ExprFloat) {
+  auto Data = encode(new nix::ExprFloat{3.14});
+  auto *E = consumeAST(Data, Pool, PT, ST);
+  EXPECT_EQ(static_cast<nix::ExprFloat *>(E)->nf, 3.14);
+  checkEmpty(Data);
+}
+
+TEST_F(DeserializeTest, ExprString) {
+  auto Data = encode(new nix::ExprString{"hello"});
+  auto *E = consumeAST(Data, Pool, PT, ST);
+  EXPECT_EQ(static_cast<nix::ExprString *>(E)->s, "hello"s);
+  checkEmpty(Data);
+}
+
+TEST_F(DeserializeTest, ExprPath) {
+  auto Data = encode(new nix::ExprPath{"hello"});
+  auto *E = consumeAST(Data, Pool, PT, ST);
+  EXPECT_EQ(static_cast<nix::ExprPath *>(E)->s, "hello"s);
+  checkEmpty(Data);
+}
+
+TEST_F(DeserializeTest, ExprVar) {
+  auto EV = std::make_unique<nix::ExprVar>(somePos(), ST.create("hello"));
+  EV->level = 43;
+  EV->displ = 42;
+  EV->fromWith = true;
+  auto Data = encode(EV.get());
+  auto *E = static_cast<nix::ExprVar *>(consumeAST(Data, Pool, PT, ST));
+  EXPECT_EQ(E->level, 43);
+  EXPECT_EQ(E->displ, 42);
+  EXPECT_EQ(E->fromWith, true);
+  EXPECT_EQ(E->name, ST.create("hello"));
+  checkEmpty(Data);
+}
+
+} // namespace

--- a/libnixt/test/Serialize.cpp
+++ b/libnixt/test/Serialize.cpp
@@ -1,0 +1,156 @@
+#include <gtest/gtest.h>
+
+#include "nixt/ArrayRef.h"
+#include "nixt/Serialize.h"
+
+using namespace nixt::serialize;
+using namespace nixt;
+using namespace std::literals;
+
+namespace {
+
+class SerializeTest : public testing::Test {
+protected:
+  nix::PosTable PT;
+  nix::SymbolTable ST;
+  std::ostringstream OS;
+  std::string Result;
+
+  template <class T>
+    requires(!std::is_pointer_v<T>)
+  BytesRef encode(const T &Obj) {
+    nixt::serialize::encode(OS, Obj);
+    Result = OS.str();
+    return {Result.data(), Result.data() + Result.size()};
+  }
+
+  BytesRef encode(const nix::Expr *E) {
+    nixt::serialize::encodeAST(OS, ST, PT, nix::Pos::none_tag{}, E);
+    Result = OS.str();
+    return {Result.data(), Result.data() + Result.size()};
+  }
+  nix::PosIdx somePos() {
+    nix::Pos::Origin O = nix::Pos::none_tag{};
+    return PT.add(O, 32, 32);
+  }
+  nix::AttrName someAttrNameSymbol() { return {ST.create("hello")}; }
+  static nix::AttrName someAttrNameExpr() { return nullptr; }
+};
+
+std::unique_ptr<nix::ExprInt> mkInt(nix::NixInt N) {
+  return std::make_unique<nix::ExprInt>(N);
+}
+
+void checkASTHeader(BytesRef &Data) {
+  auto Header = consume<ASTHeader>(Data);
+  EXPECT_EQ(std::memcmp(Header.Magic, "\x7FNixAST\0", 8), 0);
+  EXPECT_EQ(Header.Version, 1);
+}
+
+void checkTrivialOrigin(BytesRef &Data) {
+  EXPECT_EQ(consume<std::size_t>(Data), 0);
+}
+
+template <class T> void check(BytesRef &Data, T Expected) {
+  EXPECT_EQ(consume<T>(Data), Expected);
+}
+
+void checkExprInt(BytesRef &Data, nix::NixInt N) {
+  check(Data, EncodeKind::ExprInt);
+  check(Data, N);
+}
+
+void checkEmpty(BytesRef &Data) { EXPECT_EQ(lengthof(Data), 0); }
+
+void checkSomePos(BytesRef &Data) {
+  check(Data, 32);
+  check(Data, 32);
+}
+
+TEST_F(SerializeTest, Origin_none_tag) {
+  auto Data = encode(nix::Pos::Origin{nix::Pos::none_tag{}});
+  check(Data, (std::size_t)0);
+  checkEmpty(Data);
+}
+
+TEST_F(SerializeTest, Origin_Stdin) {
+  auto Data = encode(nix::Pos::Stdin{nix::make_ref<std::string>("")});
+  check(Data, (std::size_t)1);
+  checkEmpty(Data);
+}
+
+TEST_F(SerializeTest, Origin_String) {
+  auto Data = encode(nix::Pos::String{nix::make_ref<std::string>("")});
+  check(Data, (std::size_t)2);
+  checkEmpty(Data);
+}
+
+TEST_F(SerializeTest, Origin_Path) {
+  auto Data = encode(nix::CanonPath("/"));
+  check(Data, (std::size_t)3);
+  check(Data, "/"s);
+  checkEmpty(Data);
+}
+
+TEST_F(SerializeTest, ExprInt) {
+  auto Data = encode(mkInt(0xdeadbeef).get());
+  checkASTHeader(Data);
+  checkTrivialOrigin(Data);
+  checkExprInt(Data, 0xdeadbeef);
+  checkEmpty(Data);
+}
+
+TEST_F(SerializeTest, ExprFloat) {
+  union FloatUnion {
+    nix::NixFloat F;
+    uint64_t Int;
+  };
+  FloatUnion FU;
+  FU.Int = 0xdeadbeef;
+  auto EF = std::make_unique<nix::ExprFloat>(FU.F);
+  auto Data = encode(EF.get());
+  checkASTHeader(Data);
+  checkTrivialOrigin(Data);
+  check(Data, EncodeKind::ExprFloat);
+  check(Data, (uint64_t)0xdeadbeefUL);
+  checkEmpty(Data);
+}
+
+TEST_F(SerializeTest, ExprString) {
+  auto ES = std::make_unique<nix::ExprString>("hello");
+  auto Data = encode(ES.get());
+  checkASTHeader(Data);
+  checkTrivialOrigin(Data);
+  check(Data, EncodeKind::ExprString);
+  check(Data, "hello"s);
+  checkEmpty(Data);
+}
+
+TEST_F(SerializeTest, ExprPath) {
+  auto EP = std::make_unique<nix::ExprPath>(nix::Path{"hello"});
+  auto Data = encode(EP.get());
+  checkASTHeader(Data);
+  checkTrivialOrigin(Data);
+  check(Data, EncodeKind::ExprPath);
+  check(Data, "hello"s);
+  checkEmpty(Data);
+}
+
+TEST_F(SerializeTest, ExprVar) {
+  auto EV = std::make_unique<nix::ExprVar>(somePos(), ST.create("hello"));
+  EV->level = 43;
+  EV->displ = 42;
+  EV->fromWith = true;
+  auto Data = encode(EV.get());
+  checkASTHeader(Data);
+  checkTrivialOrigin(Data);
+  check(Data, EncodeKind::ExprVar);
+  checkSomePos(Data);
+  check(Data, "hello"s);
+  check(Data, true);
+  check(Data, 43);
+  check(Data, 42);
+  checkEmpty(Data);
+}
+
+} // namespace


### PR DESCRIPTION
Add serialization method for incoming IPC design. This is a binary format using POD data structures.

Only a few trivial AST nodes has been implemented.