### PR TITLE
libnixf: parse ExprPath

### DIFF
--- a/libnixf/include/nixf/Parse/Nodes.h
+++ b/libnixf/include/nixf/Parse/Nodes.h
@@ -92,6 +92,16 @@ public:
       : Kind(SPK_Interpolation), Interpolation(std::move(Expr)) {}
 
   [[nodiscard]] InterpolablePartKind kind() const { return Kind; }
+
+  [[nodiscard]] const std::string &escaped() const {
+    assert(Kind == SPK_Escaped);
+    return Escaped;
+  }
+
+  [[nodiscard]] const std::shared_ptr<Expr> &interpolation() const {
+    assert(Kind == SPK_Interpolation);
+    return Interpolation;
+  }
 };
 
 class InterpolatedParts : public Node {

--- a/libnixf/lib/Parse/Lexer.cpp
+++ b/libnixf/lib/Parse/Lexer.cpp
@@ -299,14 +299,11 @@ Token Lexer::lexPath() {
   startToken();
   Tok = tok_path_end;
   if (eof()) {
-    Tok = tok_eof;
     return finishToken();
   }
 
-  if (consumeOne('$')) {
-    if (consumePrefix("${")) {
-      Tok = tok_dollar_curly;
-    }
+  if (consumePrefix("${")) {
+    Tok = tok_dollar_curly;
     return finishToken();
   }
 

--- a/libnixf/lib/Parse/Token.h
+++ b/libnixf/lib/Parse/Token.h
@@ -26,6 +26,10 @@ constexpr std::string_view spelling(TokenKind Kind) {
     return "\"";
   case tok_quote2:
     return "''";
+  case tok_dollar_curly:
+    return "${";
+  case tok_r_curly:
+    return "}";
   default:
     assert(false && "Not yet implemented!");
   }

--- a/libnixf/lib/Parse/test/Parser.cpp
+++ b/libnixf/lib/Parse/test/Parser.cpp
@@ -179,4 +179,115 @@ TEST(Parser, IndentedString) {
   ASSERT_EQ(F.newText(), "''");
 }
 
+TEST(Parser, InterpolationOK) {
+  auto Src = R"("${1}")"sv;
+
+  DiagnosticEngine Diags;
+  auto AST = nixf::parse(Src, Diags);
+  ASSERT_TRUE(AST);
+  ASSERT_EQ(AST->kind(), Node::NK_ExprString);
+  auto Parts = static_cast<ExprString *>(AST.get())->parts();
+  ASSERT_EQ(Parts->fragments().size(), 1);
+  ASSERT_EQ(Parts->fragments()[0].kind(), InterpolablePart::SPK_Interpolation);
+  ASSERT_EQ(Diags.diags().size(), 0);
+
+  // Check the interpolation range
+  const std::shared_ptr<Expr> &I = Parts->fragments()[0].interpolation();
+  ASSERT_TRUE(I->range().begin().isAt(0, 3, 3));
+  ASSERT_TRUE(I->range().end().isAt(0, 4, 4));
+}
+
+TEST(Parser, InterpolationNoRCurly) {
+  auto Src = R"("${1")"sv;
+
+  DiagnosticEngine Diags;
+  auto AST = nixf::parse(Src, Diags);
+  ASSERT_TRUE(AST);
+  ASSERT_EQ(AST->kind(), Node::NK_ExprString);
+  auto Parts = static_cast<ExprString *>(AST.get())->parts();
+  ASSERT_EQ(Parts->fragments().size(), 1);
+  ASSERT_EQ(Parts->fragments()[0].kind(), InterpolablePart::SPK_Interpolation);
+  ASSERT_EQ(Diags.diags().size(), 1);
+
+  // Check the diagnostic.
+  auto &D = Diags.diags()[0];
+  ASSERT_TRUE(D->range().begin().isAt(0, 4, 4));
+  ASSERT_TRUE(D->range().end().isAt(0, 4, 4));
+  ASSERT_EQ(D->kind(), Diagnostic::DK_Expected);
+  ASSERT_EQ(D->args().size(), 1);
+  ASSERT_EQ(D->args()[0], "}");
+
+  // Check the note.
+  ASSERT_EQ(D->notes().size(), 1);
+  auto &N = D->notes()[0];
+  ASSERT_TRUE(N->range().begin().isAt(0, 1, 1));
+  ASSERT_TRUE(N->range().end().isAt(0, 3, 3));
+  ASSERT_EQ(N->kind(), Note::NK_ToMachThis);
+  ASSERT_EQ(N->args().size(), 1);
+  ASSERT_EQ(N->args()[0], "${");
+
+  // Check fix-it hints.
+  ASSERT_EQ(D->fixes().size(), 1);
+  const auto &F = D->fixes()[0];
+  ASSERT_TRUE(F.oldRange().begin().isAt(0, 4, 4));
+  ASSERT_TRUE(F.oldRange().end().isAt(0, 4, 4));
+  ASSERT_EQ(F.newText(), "}");
+}
+
+TEST(Parser, InterpolationNullExpr) {
+  auto Src = R"("${}")"sv;
+
+  DiagnosticEngine Diags;
+  auto AST = nixf::parse(Src, Diags);
+  ASSERT_TRUE(AST);
+  ASSERT_EQ(AST->kind(), Node::NK_ExprString);
+  auto Parts = static_cast<ExprString *>(AST.get())->parts();
+  ASSERT_EQ(Parts->fragments().size(), 0);
+
+  // Check the diagnostic.
+  auto &D = Diags.diags()[0];
+  ASSERT_TRUE(D->range().begin().isAt(0, 3, 3));
+  ASSERT_TRUE(D->range().end().isAt(0, 3, 3));
+  ASSERT_EQ(D->kind(), Diagnostic::DK_Expected);
+  ASSERT_EQ(D->args().size(), 1);
+  ASSERT_EQ(D->args()[0], "an expression as interpolation");
+
+  // Check fix-it hints.
+  ASSERT_EQ(D->fixes().size(), 1);
+  const auto &F = D->fixes()[0];
+  ASSERT_TRUE(F.oldRange().begin().isAt(0, 3, 3));
+  ASSERT_TRUE(F.oldRange().end().isAt(0, 3, 3));
+  ASSERT_EQ(F.newText(), " expr");
+}
+
+TEST(Parser, PathOK) {
+  auto Src = R"(a/b/c/${"foo"}/d)"sv;
+
+  DiagnosticEngine Diags;
+  auto AST = nixf::parse(Src, Diags);
+  ASSERT_TRUE(AST);
+  ASSERT_EQ(AST->kind(), Node::NK_ExprPath);
+  auto Parts = static_cast<ExprPath *>(AST.get())->parts();
+  ASSERT_EQ(Parts->fragments().size(), 3);
+
+  // Check the AST range
+  ASSERT_TRUE(AST->range().begin().isAt(0, 0, 0));
+  ASSERT_TRUE(AST->range().end().isAt(0, 16, 16));
+
+  // Check parts range. Should be the same as AST.
+  ASSERT_TRUE(Parts->range().begin().isAt(0, 0, 0));
+  ASSERT_TRUE(Parts->range().end().isAt(0, 16, 16));
+
+  // Check the first part.
+  ASSERT_EQ(Parts->fragments()[0].kind(), InterpolablePart::SPK_Escaped);
+  ASSERT_EQ(Parts->fragments()[0].escaped(), "a/b/c/");
+
+  // Check the second part.
+  ASSERT_EQ(Parts->fragments()[1].kind(), InterpolablePart::SPK_Interpolation);
+
+  // Check the third part.
+  ASSERT_EQ(Parts->fragments()[2].kind(), InterpolablePart::SPK_Escaped);
+  ASSERT_EQ(Parts->fragments()[2].escaped(), "/d");
+}
+
 } // namespace


### PR DESCRIPTION
### parseInterpolableParts -> parseStringParts

`StringParts` are different from path fragments because paths have no *surrounding quotes*. So, the first path fragment should be parsed normally, and the rest in "PS_Path" context. Previously `parseInterpolableParts` was used for only unified parsing contexts (and this only works for strings). So it was renamed to `parseStringParts`.