### PR TITLE
nixd: add a json schema

### DIFF
--- a/nixd/docs/nixd-schema.json
+++ b/nixd/docs/nixd-schema.json
@@ -1,0 +1,67 @@
+{
+  "$comment": "https://github.com/nix-community/nixd/blob/main/docs/user-guide.md#configuration",
+  "$id": "https://json.schemastore.org/nixd-schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "target": {
+      "description": "Nix installables that will be used for root translation unit.",
+      "type": "object",
+      "properties": {
+        "args": {
+          "description": "Accept args as \"nix eval\"",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "installable": {
+          "description": "\"nix eval\"",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "properties": {
+    "eval": {
+      "description": "The evaluation section, provide auto completion for dynamic bindings.",
+      "type": "object",
+      "properties": {
+        "target": {
+          "$ref": "#/definitions/target"
+        },
+        "depth": {
+          "description": "Extra depth for evaluation",
+          "type": "integer",
+          "default": 0
+        },
+        "workers": {
+          "description": "The number of workers for evaluation task. defaults to std::thread::hardware_concurrency",
+          "type": "integer"
+        }
+      }
+    },
+    "formatting": {
+      "command": {
+        "description": "Which command you would like to do formatting",
+        "default": "nixpkgs-fmt",
+        "type": "string"
+      }
+    },
+    "options": {
+      "description": "Tell the language server your desired option set, for completion. This is lazily evaluated.",
+      "type": "object",
+      "properties": {
+        "enable": {
+          "description": "Enable option completion task. If you are writing a package, disable this",
+          "type": "boolean",
+          "default": "false"
+        },
+        "target": {
+          "$ref": "#/definitions/target"
+        }
+      }
+    }
+  },
+  "title": "JSON schema for nixd",
+  "type": "object"
+}

--- a/nixd/docs/user-guide.md
+++ b/nixd/docs/user-guide.md
@@ -148,6 +148,18 @@ Typically, you can write a nix file, and evaluate the result into `.nixd.json`, 
 nix eval --json --file .nixd.nix > .nixd.json
 ```
 
+`.nixd.json`, the configuration of `nixd`, supports [json schema](https://json-schema.org/).
+So if your editor supports
+[LSP](https://microsoft.github.io/language-server-protocol/implementors/servers/),
+you can get completions, diagnostics and more[^json-schema]:
+
+![completion](https://github.com/nix-community/nixd/assets/32936898/013367c6-63d8-4bba-9057-c5701c2f36c1)
+
+![diagnostic](https://github.com/nix-community/nixd/assets/32936898/d285eb69-f023-4573-a8e5-8d5501ae3d16)
+
+[^json-schema]: These pictures were captured in [neovim](https://neovim.org/)
+with the plugin [coc-json](https://github.com/neoclide/coc-json).
+
 #### Evaluation
 
 ##### Target


### PR DESCRIPTION
Fix #222

1. Create a json schema
2. Add its URL to schemastore.

Now the json schema is added to this repo. I'll send a PR to add the URL of this json schema to [schema store](https://github.com/SchemaStore/schemastore)
