### PR TITLE
nixd: use orphan nixpkgs, nixos default in lit-test mode

### DIFF
--- a/nixd/include/nixd/CommandLine/Options.h
+++ b/nixd/include/nixd/CommandLine/Options.h
@@ -4,4 +4,7 @@ namespace nixd {
 
 extern llvm::cl::OptionCategory NixdCategory;
 
+/// \brief Indicating that we are in lit-test mode.
+extern llvm::cl::opt<bool> LitTest;
+
 } // namespace nixd

--- a/nixd/include/nixd/Controller/Controller.h
+++ b/nixd/include/nixd/Controller/Controller.h
@@ -136,9 +136,6 @@ private:
 
   boost::asio::thread_pool Pool;
 
-  /// In lit-test mode. Disable some concurrency for better text-testing.
-  bool LitTest;
-
   /// Action right after a document is added (including updates).
   void actOnDocumentAdd(lspserver::PathRef File,
                         std::optional<int64_t> Version);
@@ -221,8 +218,6 @@ public:
              std::unique_ptr<lspserver::OutboundPort> Out);
 
   ~Controller() override { Pool.join(); }
-
-  void setLitTest(bool LitTest) { this->LitTest = LitTest; }
 
   bool isReadyToEval() { return Eval && Eval->ready(); }
 };

--- a/nixd/lib/CommandLine/Options.cpp
+++ b/nixd/lib/CommandLine/Options.cpp
@@ -1,3 +1,10 @@
 #include "nixd/CommandLine/Options.h"
 
-llvm::cl::OptionCategory nixd::NixdCategory("nixd library options");
+using namespace llvm::cl;
+using namespace nixd;
+
+OptionCategory nixd::NixdCategory("nixd library options");
+
+opt<bool> nixd::LitTest{
+    "lit-test", desc("Indicating that the server is running in lit-test mode."),
+    init(false), cat(NixdCategory)};

--- a/nixd/lib/Controller/LifeTime.cpp
+++ b/nixd/lib/Controller/LifeTime.cpp
@@ -30,6 +30,21 @@ opt<std::string> DefaultNixOSOptionsExpr{
          "=  (import <nixpkgs/nixos/modules/module-list.nix>) ++ [ ({...}: { "
          "nixpkgs.hostPlatform = builtins.currentSystem;} ) ] ; })).options")};
 
+// Here we try to wrap nixpkgs, nixos options in a single emtpy attrset in test.
+std::string getDefaultNixpkgsExpr() {
+  if (LitTest && !DefaultNixpkgsExpr.getNumOccurrences()) {
+    return "{ }";
+  }
+  return DefaultNixpkgsExpr;
+}
+
+std::string getDefaultNixOSOptionsExpr() {
+  if (LitTest && !DefaultNixOSOptionsExpr.getNumOccurrences()) {
+    return "{ }";
+  }
+  return DefaultNixOSOptionsExpr;
+}
+
 } // namespace
 
 void Controller::evalExprWithProgress(AttrSetClient &Client,
@@ -147,7 +162,7 @@ void Controller::
   startNixpkgs(NixpkgsEval);
 
   if (nixpkgsClient()) {
-    evalExprWithProgress(*nixpkgsClient(), DefaultNixpkgsExpr,
+    evalExprWithProgress(*nixpkgsClient(), getDefaultNixpkgsExpr(),
                          "nixpkgs entries");
   }
 
@@ -157,7 +172,8 @@ void Controller::
     startOption("nixos", Options["nixos"]);
 
     if (AttrSetClient *Client = Options["nixos"]->client())
-      evalExprWithProgress(*Client, DefaultNixOSOptionsExpr, "nixos options");
+      evalExprWithProgress(*Client, getDefaultNixOSOptionsExpr(),
+                           "nixos options");
   }
   fetchConfig();
 }

--- a/nixd/lib/Controller/Support.cpp
+++ b/nixd/lib/Controller/Support.cpp
@@ -107,7 +107,7 @@ void Controller::createWorkDoneProgress(
 
 Controller::Controller(std::unique_ptr<lspserver::InboundPort> In,
                        std::unique_ptr<lspserver::OutboundPort> Out)
-    : LSPServer(std::move(In), std::move(Out)), LitTest(false) {
+    : LSPServer(std::move(In), std::move(Out)) {
 
   // Life Cycle
   Registry.addMethod("initialize", this, &Controller::onInitialize);

--- a/nixd/tools/nixd-attrset-eval.cpp
+++ b/nixd/tools/nixd-attrset-eval.cpp
@@ -1,5 +1,6 @@
 #include "nixd-config.h"
 
+#include "nixd/CommandLine/Options.h"
 #include "nixd/Eval/AttrSetProvider.h"
 
 #include <llvm/Support/CommandLine.h>
@@ -10,6 +11,7 @@
 
 using namespace llvm::cl;
 using namespace lspserver;
+using namespace nixd;
 
 namespace {
 
@@ -28,12 +30,6 @@ opt<JSONStreamStyle> InputStyle{
     cat(Debug),
     Hidden,
 };
-
-opt<bool> LitTest{
-    "lit-test",
-    desc("Abbreviation for -input-style=delimited -pretty -log=verbose. "
-         "Intended to simplify lit tests"),
-    init(false), cat(Debug)};
 
 opt<Logger::Level> LogLevel{
     "log", desc("Verbosity of log messages written to stderr"),

--- a/nixd/tools/nixd.cpp
+++ b/nixd/tools/nixd.cpp
@@ -10,6 +10,7 @@
 #include <llvm/Support/CommandLine.h>
 
 using namespace lspserver;
+using namespace nixd;
 
 namespace {
 
@@ -32,11 +33,7 @@ opt<JSONStreamStyle> InputStyle{
     cat(Debug),
     Hidden,
 };
-opt<bool> LitTest{
-    "lit-test",
-    desc("Abbreviation for -input-style=delimited -pretty -log=verbose. "
-         "Intended to simplify lit tests"),
-    init(false), cat(Debug)};
+
 opt<Logger::Level> LogLevel{
     "log", desc("Verbosity of log messages written to stderr"),
     values(
@@ -80,9 +77,6 @@ int main(int argc, char *argv[]) {
 
   auto Controller =
       std::make_unique<nixd::Controller>(std::move(In), std::move(Out));
-
-  if (LitTest)
-    Controller->setLitTest(LitTest);
 
   Controller->run();
 

--- a/nixd/tools/nixd/test/completion-nixpkgs.md
+++ b/nixd/tools/nixd/test/completion-nixpkgs.md
@@ -1,4 +1,4 @@
-# RUN: nixd --lit-test < %s | FileCheck %s
+# RUN: nixd --nixpkgs-expr='{ a = 1; b = 2; }' --lit-test < %s | FileCheck %s
 
 <-- initialize(0)
 
@@ -57,15 +57,15 @@
 ```
 
 ```
-     CHECK:    "label": "AMB-plugins",
+     CHECK:    "kind": 5,
+CHECK-NEXT:    "label": "a",
 CHECK-NEXT:    "score": 0
 CHECK-NEXT:  },
 CHECK-NEXT:  {
 CHECK-NEXT:    "data": "{\"Prefix\":\"\",\"Scope\":[]}",
 CHECK-NEXT:    "kind": 5,
-CHECK-NEXT:    "label": "ArchiSteamFarm",
+CHECK-NEXT:    "label": "b",
 CHECK-NEXT:    "score": 0
-CHECK-NEXT:  },
 ```
 
 


### PR DESCRIPTION
To speed up lit-testing, we don't need to evaluate full nixpkgs.