### PR TITLE
libnixf: fix out-of-bounds access in `Lexer::consumeManyOf`

### DIFF
--- a/libnixf/src/Parse/Lexer.cpp
+++ b/libnixf/src/Parse/Lexer.cpp
@@ -54,7 +54,7 @@ std::optional<LexerCursorRange> Lexer::consumeManyOf(std::string_view Chars) {
     return std::nullopt;
   if (Chars.find(peekUnwrap()) != std::string_view::npos) {
     auto Start = Cur;
-    while (Chars.find(peekUnwrap()) != std::string_view::npos) {
+    while (!eof() && Chars.find(peekUnwrap()) != std::string_view::npos) {
       consume();
     }
     return LexerCursorRange{Start, Cur};


### PR DESCRIPTION
While bumping my system flake I ran into a test failing due to an out-of-bounds access. It got caught by `_GLIBCXX_ASSERTIONS`. I guess the not-so-recent [bump](https://www.github.com/NixOS/nixpkgs/pull/298047) of meson in nixpkgs brought in this [commit](https://www.github.com/mesonbuild/meson/pull/12683) from meson 1.4.0.

Here's the failing test logs and a backtrace:

```bash
nixd-nightly> >>> MALLOC_PERTURB_=222 LD_LIBRARY_PATH=/build/3gwj8jwd4ypvcahxqv3cn2fq617fm7v2-source/build/libnixbc:/build/3gwj8jwd4ypvcahxqv3cn2fq617fm7v2-source/build/libnixf:/build/3gwj8jwd4ypvcahxqv3cn2fq617fm7v2-source/build/libbc ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 /build/3gwj8jwd4ypvcahxqv3cn2fq617fm7v2-source/build/libnixf/unit-libnixf-parse
nixd-nightly>  ✀
nixd-nightly> stdout:
nixd-nightly> Running main() from /build/source/googletest/src/gtest_main.cc
nixd-nightly> [==========] Running 90 tests from 2 test suites.
nixd-nightly> [----------] Global test environment set-up.
nixd-nightly> [----------] 15 tests from LexerTest
nixd-nightly> [ RUN      ] LexerTest.Integer
nixd-nightly> stderr:
nixd-nightly> /nix/store/NN152MGPDFCW92B3B03G9KMNLPD9JRIS-gcc-13.2.0/include/c++/13.2.0/string_view:258: constexpr const std::basic_string_view<_CharT, _Traits>::value_type& std::basic_string_view<_CharT, _Traits>::operator[](size_type) const [with _CharT = char; _Traits = std::char_traits<char>; const_reference = const char&; size_type = long unsigned int]: Assertion '__pos < this->_M_len' failed.
```

lldb backtrace:
```c++
(lldb) process launch --environment LD_LIBRARY_PATH=/home/xokdvium/Work/Programming/nixd/build/libnixf:/home/xokdvium/Work/Programming/nixd/build/libbc:/home/xokdvium/Work/Programming/nixd/build/libnixbc:/nix/store/fivm0vvpkfm933fd5gqj3dzni0pp50cg-pipewire-1.0.4-jack/lib ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 MALLOC_PERTURB_=239 UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1
Process 433026 launched: '/home/xokdvium/Work/Programming/nixd/build/libnixf/unit-libnixf-parse' (x86_64)
Running main() from /build/source/googletest/src/gtest_main.cc
[==========] Running 90 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 15 tests from LexerTest
[ RUN      ] LexerTest.Integer
/nix/store/NN152MGPDFCW92B3B03G9KMNLPD9JRIS-gcc-13.2.0/include/c++/13.2.0/string_view:258: constexpr const std::basic_string_view<_CharT, _Traits>::value_type& std::basic_string_view<_CharT, _Traits>::operator[](size_type) const [with _CharT = char; _Traits = std::char_traits<char>; const_reference = const char&; size_type = long unsigned int]: Assertion '__pos < this->_M_len' failed.
Process 433026 stopped
* thread #1, name = 'unit-libnixf-pa', stop reason = signal SIGABRT
    frame #0: 0x00007ffff7abfefc libc.so.6`__pthread_kill_implementation + 268
libc.so.6`__pthread_kill_implementation:
->  0x7ffff7abfefc <+268>: movl   %eax, %ebx
    0x7ffff7abfefe <+270>: negl   %ebx
    0x7ffff7abff00 <+272>: cmpl   $0xfffff000, %eax         ; imm = 0xFFFFF000
    0x7ffff7abff05 <+277>: movl   $0x0, %eax
(lldb) bt
* thread #1, name = 'unit-libnixf-pa', stop reason = signal SIGABRT
  * frame #0: 0x00007ffff7abfefc libc.so.6`__pthread_kill_implementation + 268
    frame #1: 0x00007ffff7a6fe86 libc.so.6`raise + 22
    frame #2: 0x00007ffff7a58935 libc.so.6`abort + 215
    frame #3: 0x00007ffff7d289fe libstdc++.so.6`std::__glibcxx_assert_fail(char const*, int, char const*, char const*) + 94
    frame #4: 0x00007ffff7f79f60 libnixf.so`std::basic_string_view<char, std::char_traits<char>>::operator[](this=<unavailable>, __pos=<unavailable>) const at string_view:258:2
    frame #5: 0x00007ffff7f782d6 libnixf.so`nixf::Lexer::consumeManyOf(std::basic_string_view<char, std::char_traits<char>>) [inlined] nixf::Lexer::peekUnwrap(this=0x00007fffffff73b0) const at Lexer.h:113:64
    frame #6: 0x00007ffff7f782ca libnixf.so`nixf::Lexer::consumeManyOf(this=0x00007fffffff73b0, Chars=<unavailable>) at Lexer.cpp:57:33
    frame #7: 0x00007ffff7f79258 libnixf.so`nixf::Lexer::lexNumbers() [inlined] nixf::Lexer::consumeManyDigits(this=0x00007fffffff73b0) at Lexer.h:81:25
    frame #8: 0x00007ffff7f7923f libnixf.so`nixf::Lexer::lexNumbers(this=0x00007fffffff73b0) at Lexer.cpp:195:30
    frame #9: 0x00007ffff7f79587 libnixf.so`nixf::Lexer::lex(this=0x00007fffffff73b0) at Lexer.cpp:471:15
    frame #10: 0x0000000000408a77 unit-libnixf-parse`(anonymous namespace)::LexerTest_Integer_Test::TestBody(this=0x00000000004844b0) const at Lexer.cpp:32:21
    frame #11: 0x00007ffff7f0625d libgtest.so.1.14.0`void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) + 77
    frame #12: 0x00007ffff7eed06e libgtest.so.1.14.0`testing::Test::Run() + 206
    frame #13: 0x00007ffff7eed225 libgtest.so.1.14.0`testing::TestInfo::Run() + 405
    frame #14: 0x00007ffff7eed457 libgtest.so.1.14.0`testing::TestSuite::Run() + 519
    frame #15: 0x00007ffff7efc9e7 libgtest.so.1.14.0`testing::internal::UnitTestImpl::RunAllTests() + 1143
    frame #16: 0x00007ffff7eed65b libgtest.so.1.14.0`testing::UnitTest::Run() + 123
    frame #17: 0x00007ffff7f230c0 libgtest_main.so.1.14.0`main + 64
    frame #18: 0x00007ffff7a5a10e libc.so.6`__libc_start_call_main + 126
    frame #19: 0x00007ffff7a5a1c9 libc.so.6`__libc_start_main@@GLIBC_2.34 + 137
    frame #20: 0x00000000004073a5 unit-libnixf-parse`_start + 37
```

Maybe it's a good idea to bump nixpkgs for the new default meson behavior
or enable stdlib assertions with bounds-checking explicitly?