### PR TITLE
libnixf: provide linting for escaping `with`

### DIFF
--- a/libnixf/include/nixf/Basic/DiagnosticKinds.inc
+++ b/libnixf/include/nixf/Basic/DiagnosticKinds.inc
@@ -9,7 +9,8 @@ DIAG("lex-float-no-exp", FloatNoExp, Fatal,
 DIAG("lex-float-leading-zero", FloatLeadingZero, Warning,
      "float begins with extra zeros `{}` is nixf extension")
 DIAG("parse-expected", Expected, Error, "expected {}")
-DIAG("parse-int-too-big", IntTooBig, Error, "this integer is too big for nix interpreter")
+DIAG("parse-int-too-big", IntTooBig, Error,
+     "this integer is too big for nix interpreter")
 DIAG("parse-redundant-paren", RedundantParen, Warning, "redundant parentheses")
 DIAG("parse-attrpath-extra-dot", AttrPathExtraDot, Error,
      "extra `.` at the end of attrpath")
@@ -58,4 +59,10 @@ DIAG("sema-def-not-used", DefinitionNotUsed, Warning,
 DIAG("sema-extra-rec", ExtraRecursive, Warning,
      "attrset is not necessary to be `rec`ursive ")
 DIAG("sema-extra-with", ExtraWith, Warning, "unused `with` expression")
+
+// let a = 1; b = { a = 2; }; with b;  a
+// "a" will bind to "let", not "with", that is not very intuitive.
+DIAG("sema-escaping-with", EscapingWith, Warning,
+     "this variable will escape nested `with`, binding to static name")
+
 #endif // DIAG

--- a/libnixf/include/nixf/Basic/NoteKinds.inc
+++ b/libnixf/include/nixf/Basic/NoteKinds.inc
@@ -10,4 +10,7 @@ DIAG_NOTE("merge-diff-rec-consider", RecConsider,
           "will be considered as {}recursive")
 DIAG_NOTE("note-bcomment-begin", BCommentBegin, "/* comment begins at here")
 DIAG_NOTE("to-match-this", ToMachThis, "to match this {}")
+DIAG_NOTE("var-bind-to-this", VarBindToThis,
+          "variable will bind to this definition")
+DIAG_NOTE("escaping-this-with", EscapingWith, "escaping this with expression")
 #endif // DIAG_NOTE

--- a/libnixf/src/Sema/VariableLookup.cpp
+++ b/libnixf/src/Sema/VariableLookup.cpp
@@ -79,6 +79,8 @@ void VariableLookupAnalysis::lookupVar(const ExprVar &Var,
     if (EnclosedWith) {
       // Escaping from "with" to outer scope.
       // https://github.com/NixOS/nix/issues/490
+
+      assert(WithEnv && "EnclosedWith -> WithEnv");
       // Make a diagnostic.
       Diagnostic &D =
           Diags.emplace_back(Diagnostic::DK_EscapingWith, Var.range());

--- a/libnixf/src/Sema/VariableLookup.cpp
+++ b/libnixf/src/Sema/VariableLookup.cpp
@@ -75,6 +75,18 @@ void VariableLookupAnalysis::lookupVar(const ExprVar &Var,
   if (Def) {
     Def->usedBy(Var);
     Results.insert({&Var, LookupResult{LookupResultKind::Defined, Def}});
+
+    if (EnclosedWith) {
+      // Escaping from "with" to outer scope.
+      // https://github.com/NixOS/nix/issues/490
+      // Make a diagnostic.
+      Diagnostic &D =
+          Diags.emplace_back(Diagnostic::DK_EscapingWith, Var.range());
+      if (Def->syntax()) {
+        D.note(Note::NK_VarBindToThis, Def->syntax()->range());
+      }
+      D.note(Note::NK_EscapingWith, WithEnv->syntax()->range());
+    }
     return;
   }
   if (EnclosedWith) {

--- a/libnixf/test/Sema/VariableLookup.cpp
+++ b/libnixf/test/Sema/VariableLookup.cpp
@@ -250,4 +250,16 @@ TEST_F(VLATest, FormalDef) {
   ASSERT_EQ(Diags.size(), 0);
 }
 
+TEST_F(VLATest, EscapingWith) {
+  std::shared_ptr<Node> AST = parse("a: with { a = 1; b = 2; }; a + b", Diags);
+  VariableLookupAnalysis VLA(Diags);
+  VLA.runOnAST(*AST);
+
+  ASSERT_EQ(Diags.size(), 1);
+
+  const Diagnostic &D = Diags[0];
+
+  ASSERT_EQ(D.notes().size(), 2);
+}
+
 } // namespace


### PR DESCRIPTION
Provide diagnostic mentioned in https://github.com/NixOS/nix/issues/490

![image](https://github.com/nix-community/nixd/assets/36667224/4db9ed38-e07e-4dc3-b3e5-9d5943aaa880)
