### PR TITLE
{libnixt,nixd/Eval}: support `attrsOf submodule`

### DIFF
--- a/libnixt/include/nixt/Value.h
+++ b/libnixt/include/nixt/Value.h
@@ -33,10 +33,23 @@ std::vector<nix::Symbol> toSymbols(nix::SymbolTable &STable,
 /// \brief Select attribute \p Attr
 nix::Value &selectAttr(nix::EvalState &State, nix::Value &V, nix::Symbol Attr);
 
+nix::Value &selectOption(nix::EvalState &State, nix::Value &V,
+                         nix::Symbol Attr);
+
 /// \brief Given an attrpath in nix::Value \p V, select it
 nix::Value &selectAttrPath(nix::EvalState &State, nix::Value &V,
                            std::vector<nix::Symbol>::const_iterator Begin,
                            std::vector<nix::Symbol>::const_iterator End);
+
+/// \brief Select the option declaration list, \p V,  dive into "submodules".
+nix::Value &selectOptions(nix::EvalState &State, nix::Value &V,
+                          std::vector<nix::Symbol>::const_iterator Begin,
+                          std::vector<nix::Symbol>::const_iterator End);
+
+inline nix::Value &selectOptions(nix::EvalState &State, nix::Value &V,
+                                 const std::vector<nix::Symbol> &AttrPath) {
+  return selectOptions(State, V, AttrPath.begin(), AttrPath.end());
+}
 
 /// \copydoc selectAttrPath
 inline nix::Value &selectSymbols(nix::EvalState &State, nix::Value &V,

--- a/nixd/lib/Eval/AttrSetProvider.cpp
+++ b/nixd/lib/Eval/AttrSetProvider.cpp
@@ -232,7 +232,8 @@ void AttrSetProvider::onOptionInfo(
       return;
     }
 
-    nix::Value &Option = nixt::selectStrings(state(), Nixpkgs, AttrPath);
+    nix::Value &Option = nixt::selectOptions(
+        state(), Nixpkgs, nixt::toSymbols(state().symbols, AttrPath));
 
     OptionInfoResponse R;
 
@@ -253,7 +254,8 @@ void AttrSetProvider::onOptionComplete(
     const AttrPathCompleteParams &Params,
     lspserver::Callback<OptionCompleteResponse> Reply) {
   try {
-    nix::Value &Scope = nixt::selectStrings(state(), Nixpkgs, Params.Scope);
+    nix::Value &Scope = nixt::selectOptions(
+        state(), Nixpkgs, nixt::toSymbols(state().symbols, Params.Scope));
 
     state().forceValue(Scope, nix::noPos);
 


### PR DESCRIPTION
Currently these options are nested under

`foo.bar.<name>.options`

Fixes: #106