### PR TITLE
libnixf/Sema: place `with` warning only on its keyword

### DIFF
--- a/libnixf/src/Sema/VariableLookup.cpp
+++ b/libnixf/src/Sema/VariableLookup.cpp
@@ -92,7 +92,9 @@ void VariableLookupAnalysis::lookupVar(const ExprVar &Var,
       if (Def->syntax()) {
         D.note(Note::NK_VarBindToThis, Def->syntax()->range());
       }
-      D.note(Note::NK_EscapingWith, WithEnv->syntax()->range());
+      const auto &KwWith =
+          static_cast<const nixf::ExprWith *>(WithEnv->syntax())->kwWith();
+      D.note(Note::NK_EscapingWith, KwWith.range());
     }
     return;
   }

--- a/libnixf/test/Sema/VariableLookup.cpp
+++ b/libnixf/test/Sema/VariableLookup.cpp
@@ -260,6 +260,14 @@ TEST_F(VLATest, EscapingWith) {
   const Diagnostic &D = Diags[0];
 
   ASSERT_EQ(D.notes().size(), 2);
+
+  ASSERT_EQ(D.notes()[0].kind(), Note::NK_VarBindToThis);
+  ASSERT_EQ(D.notes()[0].range().lCur().offset(), 0);
+  ASSERT_EQ(D.notes()[0].range().rCur().offset(), 1);
+
+  ASSERT_EQ(D.notes()[1].kind(), Note::NK_EscapingWith);
+  ASSERT_EQ(D.notes()[1].range().lCur().offset(), 3);
+  ASSERT_EQ(D.notes()[1].range().rCur().offset(), 7);
 }
 
 TEST_F(VLATest, InheritRec) {


### PR DESCRIPTION
Fixes: #475