### PR TITLE
docs(configuration): Add configuration for a `perSystem` flake-parts option

### DIFF
--- a/nixd/docs/configuration.md
+++ b/nixd/docs/configuration.md
@@ -204,6 +204,10 @@ In our option system, you need to specify which option set you'd like to use.
     // https://flake.parts/debug
     "flake-parts": {
       "expr": "(builtins.getFlake \"/path/to/your/flake\").debug.options"
+    },
+    // For a `perSystem` flake-parts option:
+    "flake-parts2": {
+      "expr": "(builtins.getFlake \"/path/to/your/flake\").currentSystem.options"
     }
   }
 }


### PR DESCRIPTION
Here’s what the `debug.options` and `currentSystem.options` looks like in [services-flake’s dev flake](https://github.com/juspay/services-flake/tree/main/dev):

```sh
services-flake/dev on  main [!] via ❄️  impure (nix-shell-env) took 2m9s
❯ nix repl
Welcome to Nix 2.18.2. Type :? for help.

nix-repl> :lf .
warning: Git tree '/Users/shivaraj/oss/services-flake' is dirty
Added 23 variables.

nix-repl> currentSystem.options
{ _module = { ... }; allModuleArgs = { ... }; apps = { ... }; checks = { ... }; debug = { ... }; devShells = { ... }; flake-root = { ... }; formatter = { ... }; legacyPackages = { ... }; packages = { ... }; pre-commit = { ... }; treefmt = { ... }; }

nix-repl> debug.options
{ _module = { ... }; allSystems = { ... }; debug = { ... }; flake = { ... }; perInput = { ... }; perSystem = { ... }; systems = { ... }; transposition = { ... }; }
```

`currentSystem.options` comprises of `pre-commit` and `treefmt` options, whereas `debug.options` doesn’t.