### PR TITLE
libnixf: fix missing visitor for `ExprPath`

### DIFF
--- a/libnixf/include/nixf/Basic/Nodes/Simple.h
+++ b/libnixf/include/nixf/Basic/Nodes/Simple.h
@@ -154,7 +154,7 @@ public:
     return *Parts;
   }
 
-  [[nodiscard]] ChildVector children() const override { return {}; }
+  [[nodiscard]] ChildVector children() const override { return {Parts.get()}; }
 };
 
 class ExprSPath : public Expr {

--- a/nixd/tools/nixd/test/diagnostic-liveness-path.md
+++ b/nixd/tools/nixd/test/diagnostic-liveness-path.md
@@ -1,0 +1,40 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```json
+{
+   "jsonrpc":"2.0",
+   "method":"textDocument/didOpen",
+   "params":{
+      "textDocument":{
+         "uri":"file:///basic.nix",
+         "languageId":"nix",
+         "version":1,
+         "text":"{x, y}: ./${x}/${y}"
+      }
+   }
+}
+```
+
+```
+     CHECK: "diagnostics": []
+```


### PR DESCRIPTION
Fixes: https://github.com/nix-community/nixd/issues/472