### PR TITLE
pkg: add a non-generic description

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation {
 
   meta = {
     mainProgram = "nixd";
-    description = "Nix language server";
+    description = "A feature-rich Nix language server interoperating with C++ nix";
     homepage = "https://github.com/nix-community/nixd";
     license = lib.licenses.lgpl3Plus;
     maintainers = with lib.maintainers; [ inclyc ];


### PR DESCRIPTION
There are many Nix LSP servers, so let's use a description that's unique to nixd.

Note: this description is shown via LSP in VSCode:

<img width="313" alt="image" src="https://github.com/nix-community/nixd/assets/3998/0a65e3c9-81b0-422e-849b-614a57c13516">
