### PR TITLE
libnixf: fix variable lookup not visiting empty let ... in ... expr

### DIFF
--- a/libnixf/test/Sema/VariableLookup.cpp
+++ b/libnixf/test/Sema/VariableLookup.cpp
@@ -280,4 +280,14 @@ TEST_F(VLATest, InheritRec) {
   ASSERT_EQ(Diags.size(), 0);
 }
 
+TEST_F(VLATest, EmptyLetIn) {
+  // Test that emtpy let ... in ... expression is considered.
+  // https://github.com/nix-community/nixd/issues/500
+  std::shared_ptr<Node> AST = parse("{ config }: let in config", Diags);
+  VariableLookupAnalysis VLA(Diags);
+  VLA.runOnAST(*AST);
+
+  ASSERT_EQ(Diags.size(), 0);
+}
+
 } // namespace


### PR DESCRIPTION
Emtpy let ... in ... expression, leaving a nullptr in libnixf's "Let" struct, causes the code not continue visiting the body at all.

Fixes: #500