### PR TITLE
libnixf/Sema: fix attribute source context of `inherit (expr) ...`

### DIFF
--- a/libnixf/include/nixf/Basic/Nodes/Attrs.h
+++ b/libnixf/include/nixf/Basic/Nodes/Attrs.h
@@ -187,14 +187,25 @@ public:
 };
 
 class Attribute {
+public:
+  enum class AttributeKind {
+    /// a = b;
+    Plain,
+    /// inherit a b c;
+    Inherit,
+    /// inherit (expr) a b c
+    InheritFrom,
+  };
+
+private:
   const std::shared_ptr<Node> Key;
   const std::shared_ptr<Expr> Value;
-  const bool FromInherit;
+  AttributeKind Kind;
 
 public:
   Attribute(std::shared_ptr<Node> Key, std::shared_ptr<Expr> Value,
-            bool FromInherit)
-      : Key(std::move(Key)), Value(std::move(Value)), FromInherit(FromInherit) {
+            AttributeKind Kind)
+      : Key(std::move(Key)), Value(std::move(Value)), Kind(Kind) {
     assert(this->Key && "Key must not be null");
   }
 
@@ -202,7 +213,11 @@ public:
 
   [[nodiscard]] Expr *value() const { return Value.get(); }
 
-  [[nodiscard]] bool fromInherit() const { return FromInherit; }
+  [[nodiscard]] AttributeKind kind() const { return Kind; }
+
+  [[nodiscard]] bool fromInherit() const {
+    return Kind == AttributeKind::InheritFrom || Kind == AttributeKind::Inherit;
+  }
 };
 
 /// \brief Attribute set after deduplication.

--- a/libnixf/include/nixf/Sema/SemaActions.h
+++ b/libnixf/include/nixf/Sema/SemaActions.h
@@ -45,7 +45,7 @@ public:
   std::shared_ptr<Formals> onFormals(LexerCursorRange Range, FormalVector FV);
 
   /// \brief Desugar inherit (expr) a, inherit a, into select, or variable.
-  static std::shared_ptr<Expr>
+  static std::pair<std::shared_ptr<Expr>, Attribute::AttributeKind>
   desugarInheritExpr(std::shared_ptr<AttrName> Name, std::shared_ptr<Expr> E);
 
   void dupAttr(std::string Name, LexerCursorRange Range, LexerCursorRange Prev);
@@ -72,7 +72,7 @@ public:
 
   /// \note Name must not be null
   void insertAttr(SemaAttrs &SA, std::shared_ptr<AttrName> Name,
-                  std::shared_ptr<Expr> E, bool IsInherit);
+                  std::shared_ptr<Expr> E, Attribute::AttributeKind Kind);
 
   /// Select into \p Attr the attribute specified by \p Path, or create one if
   /// not exists, until reached the inner-most attr. Similar to `mkdir -p`.
@@ -85,7 +85,8 @@ public:
   void addAttr(SemaAttrs &Attr, const AttrPath &Path, std::shared_ptr<Expr> E);
 
   void lowerInheritName(SemaAttrs &SA, std::shared_ptr<AttrName> Name,
-                        std::shared_ptr<Expr> E);
+                        std::shared_ptr<Expr> E,
+                        Attribute::AttributeKind InheritKind);
 
   void lowerInherit(SemaAttrs &Attr, const Inherit &Inherit);
 

--- a/libnixf/src/Sema/VariableLookup.cpp
+++ b/libnixf/src/Sema/VariableLookup.cpp
@@ -182,7 +182,13 @@ std::shared_ptr<EnvNode> VariableLookupAnalysis::dfsAttrs(
     for (const auto &[_, Attr] : SA.staticAttrs()) {
       if (!Attr.value())
         continue;
-      dfs(*Attr.value(), NewEnv);
+      if (Attr.kind() == Attribute::AttributeKind::Plain ||
+          Attr.kind() == Attribute::AttributeKind::InheritFrom)
+        dfs(*Attr.value(), NewEnv);
+      else {
+        assert(Attr.kind() == Attribute::AttributeKind::Inherit);
+        dfs(*Attr.value(), Env);
+      }
     }
 
     dfsDynamicAttrs(SA.dynamicAttrs(), NewEnv);

--- a/libnixf/src/Sema/VariableLookup.cpp
+++ b/libnixf/src/Sema/VariableLookup.cpp
@@ -183,9 +183,9 @@ std::shared_ptr<EnvNode> VariableLookupAnalysis::dfsAttrs(
       if (!Attr.value())
         continue;
       if (Attr.kind() == Attribute::AttributeKind::Plain ||
-          Attr.kind() == Attribute::AttributeKind::InheritFrom)
+          Attr.kind() == Attribute::AttributeKind::InheritFrom) {
         dfs(*Attr.value(), NewEnv);
-      else {
+      } else {
         assert(Attr.kind() == Attribute::AttributeKind::Inherit);
         dfs(*Attr.value(), Env);
       }

--- a/libnixf/test/Sema/SemaActions.cpp
+++ b/libnixf/test/Sema/SemaActions.cpp
@@ -110,11 +110,12 @@ TEST_F(SemaActionTest, insertAttrDup) {
       {"a", Attribute(
                 /*Key=*/Name,
                 /*Value=*/std::make_shared<ExprInt>(LexerCursorRange{}, 1),
-                /*FromInherit=*/false)});
+                Attribute::AttributeKind::Plain)});
 
   SemaAttrs A(std::move(Attrs), {}, nullptr);
   std::shared_ptr<ExprInt> E(new ExprInt{{}, 1});
-  L.insertAttr(A, std::move(Name), std::move(E), false); // Duplicated
+  L.insertAttr(A, std::move(Name), std::move(E),
+               Attribute::AttributeKind::Plain); // Duplicated
 
   ASSERT_EQ(A.staticAttrs().size(), 1);
   ASSERT_EQ(Diags.size(), 1);
@@ -126,7 +127,7 @@ TEST_F(SemaActionTest, insertAttrOK) {
   // Check we can detect duplicated attr.
   std::shared_ptr<ExprInt> E(new ExprInt{{}, 1});
   L.insertAttr(SA, std::move(Name), std::move(E),
-               /*IsInherit=*/false); // Duplicated
+               Attribute::AttributeKind::Plain); // Duplicated
   ASSERT_EQ(SA.staticAttrs().size(), 1);
   ASSERT_EQ(Diags.size(), 0);
 }
@@ -136,7 +137,7 @@ TEST_F(SemaActionTest, insertAttrNullptr) {
   auto Name = getStaticName("a");
   std::shared_ptr<ExprInt> E(new ExprInt{{}, 1});
   L.insertAttr(SA, std::move(Name), std::move(E),
-               /*IsInherit=*/false); // Duplicated
+               Attribute::AttributeKind::Plain); // Duplicated
   ASSERT_EQ(SA.staticAttrs().size(), 1);
   ASSERT_EQ(Diags.size(), 0);
 }
@@ -144,8 +145,7 @@ TEST_F(SemaActionTest, insertAttrNullptr) {
 TEST_F(SemaActionTest, insertAttrNullptr2) {
   SemaAttrs SA(nullptr);
   auto Name = getDynamicName();
-  L.insertAttr(SA, std::move(Name), nullptr,
-               /*IsInherit=*/false);
+  L.insertAttr(SA, std::move(Name), nullptr, Attribute::AttributeKind::Plain);
   ASSERT_EQ(SA.staticAttrs().size(), 0);
   ASSERT_EQ(SA.dynamicAttrs().size(), 0);
   ASSERT_EQ(Diags.size(), 0);
@@ -155,7 +155,8 @@ TEST_F(SemaActionTest, inheritName) {
   SemaAttrs Attr(nullptr);
   auto Name = getStaticName("a");
 
-  L.lowerInheritName(Attr, std::move(Name), nullptr);
+  L.lowerInheritName(Attr, std::move(Name), nullptr,
+                     Attribute::AttributeKind::Inherit);
   ASSERT_EQ(Attr.staticAttrs().size(), 1);
   ASSERT_EQ(Diags.size(), 0);
 }
@@ -164,7 +165,7 @@ TEST_F(SemaActionTest, inheritNameNullptr) {
   SemaAttrs Attr(nullptr);
   auto Name = getStaticName("a");
 
-  L.lowerInheritName(Attr, nullptr, nullptr);
+  L.lowerInheritName(Attr, nullptr, nullptr, Attribute::AttributeKind::Inherit);
   ASSERT_EQ(Attr.staticAttrs().size(), 0);
   ASSERT_EQ(Diags.size(), 0);
 }
@@ -174,7 +175,7 @@ TEST_F(SemaActionTest, inheritNameDynamic) {
   auto Name = getDynamicName(
       {LexerCursor::unsafeCreate(0, 0, 1), LexerCursor::unsafeCreate(0, 1, 2)});
 
-  L.lowerInheritName(Attr, Name, nullptr);
+  L.lowerInheritName(Attr, Name, nullptr, Attribute::AttributeKind::Inherit);
   ASSERT_EQ(Attr.staticAttrs().size(), 0);
   ASSERT_EQ(Attr.dynamicAttrs().size(), 0);
   ASSERT_EQ(Diags.size(), 1);
@@ -198,10 +199,10 @@ TEST_F(SemaActionTest, inheritNameDuplicated) {
       {"a", Attribute(
                 /*Key=*/Name,
                 /*Value=*/std::make_shared<ExprInt>(LexerCursorRange{}, 1),
-                /*FromInherit=*/false)});
+                Attribute::AttributeKind::Plain)});
 
   SemaAttrs SA(std::move(Attrs), {}, nullptr);
-  L.lowerInheritName(SA, Name, nullptr);
+  L.lowerInheritName(SA, Name, nullptr, Attribute::AttributeKind::Inherit);
   ASSERT_EQ(SA.staticAttrs().size(), 1);
   ASSERT_EQ(Diags.size(), 1);
 }
@@ -222,13 +223,13 @@ TEST_F(SemaActionTest, mergeAttrSets) {
       {"a", Attribute(
                 /*Key=*/XName,
                 /*Value=*/std::make_shared<ExprInt>(LexerCursorRange{}, 1),
-                /*FromInherit=*/false)});
+                Attribute::AttributeKind::Plain)});
 
   YAttrs.insert(
       {"a", Attribute(
                 /*Key=*/YName,
                 /*Value=*/std::make_shared<ExprInt>(LexerCursorRange{}, 1),
-                /*FromInherit=*/false)});
+                Attribute::AttributeKind::Plain)});
 
   SemaAttrs XA(XAttrs, {}, nullptr);
   SemaAttrs YA(YAttrs, {}, nullptr);

--- a/libnixf/test/Sema/VariableLookup.cpp
+++ b/libnixf/test/Sema/VariableLookup.cpp
@@ -303,6 +303,9 @@ rec {
   std::shared_ptr<Node> AST = parse(Src, Diags);
   VariableLookupAnalysis VLA(Diags);
   VLA.runOnAST(*AST);
+
+  ASSERT_EQ(Diags.size(), 1);
+  ASSERT_EQ(Diags[0].range().lCur().line(), 3);
 }
 
 } // namespace

--- a/libnixf/test/Sema/VariableLookup.cpp
+++ b/libnixf/test/Sema/VariableLookup.cpp
@@ -290,4 +290,19 @@ TEST_F(VLATest, EmptyLetIn) {
   ASSERT_EQ(Diags.size(), 0);
 }
 
+TEST_F(VLATest, Issue513) {
+  // #513
+  const char *Src = R"(
+rec {
+  a = 1;
+  b = rec {
+    inherit a;
+  };
+})";
+
+  std::shared_ptr<Node> AST = parse(Src, Diags);
+  VariableLookupAnalysis VLA(Diags);
+  VLA.runOnAST(*AST);
+}
+
 } // namespace


### PR DESCRIPTION
Consider recursive attributes:

    rec {
        inherit (expr) attr;
        inherit attr;
    }

The syntax:

    inherit (expr) attr

is desugared into

    attr = expr.attr

.

The expression `expr.attr` should be evaluated in new environment, created by `rec` keyword

However,

    inherit attr

desugaring to

    attr = attr

should be evaluated in parent environment.

This scoping rule is somehow straightfoward but not really documented. libnixf previously evaluated the second case in "new environment".

Fixes: #513