### PR TITLE
nixd/Controller: fix character number -> 0

### DIFF
--- a/nixd/lib/Controller/Definition.cpp
+++ b/nixd/lib/Controller/Definition.cpp
@@ -125,7 +125,7 @@ class NixpkgsDefinitionProvider {
       };
     }
     int PosL = std::stoi(std::string(Position.substr(Pos + 1)));
-    lspserver::Position P{PosL, PosL};
+    lspserver::Position P{PosL, 0};
     std::string_view File = Position.substr(0, Pos);
     return Location{
         .uri = URIForFile::canonicalize(File, File),

--- a/nixd/tools/nixd/test/definition-package.md
+++ b/nixd/tools/nixd/test/definition-package.md
@@ -62,11 +62,11 @@ CHECK-NEXT: "result": [
 CHECK-NEXT:   {
 CHECK-NEXT:     "range": {
 CHECK-NEXT:       "end": {
-CHECK-NEXT:         "character": 33,
+CHECK-NEXT:         "character": 0,
 CHECK-NEXT:         "line": 33
 CHECK-NEXT:       },
 CHECK-NEXT:       "start": {
-CHECK-NEXT:         "character": 33,
+CHECK-NEXT:         "character": 0,
 CHECK-NEXT:         "line": 33
 CHECK-NEXT:       }
 CHECK-NEXT:     },


### PR DESCRIPTION
Nixpkgs meta.positions does not have any character information, only line numbers get retrieved.
Previously this number will be assigned with randomly, say, equals to line numbers.

This PR fixup that character number to zero as if there may be some rendering issue for neovim.

Fixes: #523