### PR TITLE
nixd/hover: hover documentation for options

### DIFF
--- a/nixd/lib/Controller/Hover.cpp
+++ b/nixd/lib/Controller/Hover.cpp
@@ -71,7 +71,8 @@ class NixpkgsHoverProvider {
     }
 
     if (Package.Description) {
-      OS << "## Description" << "\n\n";
+      OS << "## Description"
+         << "\n\n";
       OS << *Package.Description;
       OS << "\n\n";
 

--- a/nixd/lib/Controller/Hover.cpp
+++ b/nixd/lib/Controller/Hover.cpp
@@ -27,8 +27,8 @@ class OptionsHoverProvider {
 
 public:
   OptionsHoverProvider(AttrSetClient &Client) : Client(Client) {}
-  std::optional<OptionDescription> resolveHover(const std::vector<std::string> &Scope,
-                                                std::string Name) {
+  std::optional<OptionDescription>
+  resolveHover(const std::vector<std::string> &Scope) {
     std::binary_semaphore Ready(0);
     std::optional<OptionDescription> Desc;
     auto OnReply = [&Ready, &Desc](llvm::Expected<OptionInfoResponse> Resp) {
@@ -40,7 +40,6 @@ public:
     };
 
     Client.optionInfo(Scope, std::move(OnReply));
-    Scope.emplace_back(std::move(Name));
     Ready.acquire();
 
     return Desc;

--- a/nixd/lib/Controller/Hover.cpp
+++ b/nixd/lib/Controller/Hover.cpp
@@ -27,7 +27,7 @@ class OptionsHoverProvider {
 
 public:
   OptionsHoverProvider(AttrSetClient &Client) : Client(Client) {}
-  std::optional<OptionDescription> resolveHover(std::vector<std::string> Scope,
+  std::optional<OptionDescription> resolveHover(const std::vector<std::string> &Scope,
                                                 std::string Name) {
     std::binary_semaphore Ready(0);
     std::optional<OptionDescription> Desc;

--- a/nixd/lib/Controller/Hover.cpp
+++ b/nixd/lib/Controller/Hover.cpp
@@ -156,7 +156,7 @@ void Controller::onHover(const TextDocumentPositionParams &Params,
               OptionsHoverProvider OHP(*C);
               std::optional<OptionDescription> Desc =
                   OHP.resolveHover(Scope, Name);
-              std::string Docs = "";
+              std::string Docs;
               if (Desc) {
                 if (Desc->Type) {
                   std::string TypeName = Desc->Type->Name.value_or("");

--- a/nixd/lib/Controller/Hover.cpp
+++ b/nixd/lib/Controller/Hover.cpp
@@ -22,6 +22,31 @@ using namespace lspserver;
 
 namespace {
 
+class OptionsHoverProvider {
+  AttrSetClient &Client;
+
+public:
+  OptionsHoverProvider(AttrSetClient &Client) : Client(Client) {}
+  std::optional<OptionDescription> resolveHover(std::vector<std::string> Scope,
+                                                std::string Name) {
+    std::binary_semaphore Ready(0);
+    std::optional<OptionDescription> Desc;
+    auto OnReply = [&Ready, &Desc](llvm::Expected<OptionInfoResponse> Resp) {
+      if (Resp)
+        Desc = *Resp;
+      else
+        elog("options hover: {0}", Resp.takeError());
+      Ready.release();
+    };
+
+    Client.optionInfo(Scope, std::move(OnReply));
+    Scope.emplace_back(std::move(Name));
+    Ready.acquire();
+
+    return Desc;
+  }
+};
+
 /// \brief Provide package information, library information ... , from nixpkgs.
 class NixpkgsHoverProvider {
   AttrSetClient &NixpkgsClient;
@@ -46,8 +71,7 @@ class NixpkgsHoverProvider {
     }
 
     if (Package.Description) {
-      OS << "## Description"
-         << "\n\n";
+      OS << "## Description" << "\n\n";
       OS << *Package.Description;
       OS << "\n\n";
 
@@ -122,6 +146,42 @@ void Controller::onHover(const TextDocumentPositionParams &Params,
             return;
           }
         }
+
+        std::vector<std::string> Scope;
+        auto R = findAttrPath(*N, PM, Scope);
+        if (R == FindAttrPathResult::OK) {
+          std::lock_guard _(OptionsLock);
+          for (const auto &[_, Client] : Options) {
+            if (AttrSetClient *C = Client->client()) {
+              OptionsHoverProvider OHP(*C);
+              std::optional<OptionDescription> Desc =
+                  OHP.resolveHover(Scope, Name);
+              std::string Docs = "";
+              if (Desc) {
+                if (Desc->Type) {
+                  std::string TypeName = Desc->Type->Name.value_or("");
+                  std::string TypeDesc = Desc->Type->Description.value_or("");
+                  Docs += llvm::formatv("{0} ({1})", TypeName, TypeDesc);
+                } else {
+                  Docs += "? (missing type)";
+                }
+                if (Desc->Description) {
+                  Docs += "\n" + Desc->Description.value_or("");
+                }
+                Reply(Hover{
+                    .contents =
+                        MarkupContent{
+                            .kind = MarkupKind::Markdown,
+                            .value = std::move(Docs),
+                        },
+                    .range = toLSPRange(N->range()),
+                });
+                return;
+              }
+            }
+          }
+        }
+
         // Reply it's kind by static analysis
         // FIXME: support more.
         Reply(Hover{

--- a/nixd/lib/Controller/Hover.cpp
+++ b/nixd/lib/Controller/Hover.cpp
@@ -164,7 +164,7 @@ void Controller::onHover(const TextDocumentPositionParams &Params,
                   Docs += "? (missing type)";
                 }
                 if (Desc->Description) {
-                  Docs += "\n" + Desc->Description.value_or("");
+                  Docs += "\n\n" + Desc->Description.value_or("");
                 }
                 Reply(Hover{
                     .contents =

--- a/nixd/lib/Controller/Hover.cpp
+++ b/nixd/lib/Controller/Hover.cpp
@@ -70,8 +70,7 @@ class NixpkgsHoverProvider {
     }
 
     if (Package.Description) {
-      OS << "## Description"
-         << "\n\n";
+      OS << "## Description" << "\n\n";
       OS << *Package.Description;
       OS << "\n\n";
 
@@ -154,8 +153,7 @@ void Controller::onHover(const TextDocumentPositionParams &Params,
           for (const auto &[_, Client] : Options) {
             if (AttrSetClient *C = Client->client()) {
               OptionsHoverProvider OHP(*C);
-              std::optional<OptionDescription> Desc =
-                  OHP.resolveHover(Scope, Name);
+              std::optional<OptionDescription> Desc = OHP.resolveHover(Scope);
               std::string Docs;
               if (Desc) {
                 if (Desc->Type) {

--- a/nixd/tools/nixd/test/hover-options.md
+++ b/nixd/tools/nixd/test/hover-options.md
@@ -64,7 +64,7 @@ CHECK-NEXT:  "jsonrpc": "2.0",
 CHECK-NEXT:  "result": {
 CHECK-NEXT:    "contents": {
 CHECK-NEXT:      "kind": "markdown",
-CHECK-NEXT:      "value": " (hello type)\ntest"
+CHECK-NEXT:      "value": " (hello type)\n\ntest"
 CHECK-NEXT:    },
 CHECK-NEXT:    "range": {
 CHECK-NEXT:      "end": {

--- a/nixd/tools/nixd/test/hover-options.md
+++ b/nixd/tools/nixd/test/hover-options.md
@@ -1,0 +1,83 @@
+# RUN: nixd --lit-test \
+# RUN: --nixos-options-expr="{ foo.bar = { _type = \"option\"; }; }" \
+# RUN: < %s | FileCheck %s
+
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```json
+{
+   "jsonrpc":"2.0",
+   "method":"textDocument/didOpen",
+   "params":{
+      "textDocument":{
+         "uri":"file:///basic.nix",
+         "languageId":"nix",
+         "version":1,
+         "text":"{ foo.bar = 1 }"
+      }
+   }
+}
+```
+
+<-- textDocument/hover(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/hover",
+   "params":{
+      "textDocument":{
+         "uri":"file:///basic.nix"
+      },
+      "position":{
+         "line":0,
+         "character":6
+      }
+   }
+}
+```
+
+```
+     CHECK: "id": 2,
+CHECK-NEXT: "jsonrpc": "2.0",
+CHECK-NEXT: "result": {
+CHECK-NEXT:   "contents": {
+CHECK-NEXT:     "kind": "markdown",
+CHECK-NEXT:     "value": "`Identifer`"
+CHECK-NEXT:   },
+CHECK-NEXT:   "range": {
+CHECK-NEXT:     "end": {
+CHECK-NEXT:       "character": 9,
+CHECK-NEXT:       "line": 0
+CHECK-NEXT:     },
+CHECK-NEXT:     "start": {
+CHECK-NEXT:       "character": 6,
+CHECK-NEXT:       "line": 0
+CHECK-NEXT:     }
+CHECK-NEXT:   }
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/hover-options.md
+++ b/nixd/tools/nixd/test/hover-options.md
@@ -64,7 +64,7 @@ CHECK-NEXT: "jsonrpc": "2.0",
 CHECK-NEXT: "result": {
 CHECK-NEXT:   "contents": {
 CHECK-NEXT:     "kind": "markdown",
-CHECK-NEXT:     "value": "`Identifer`"
+CHECK-NEXT:     "value": "? (missing type)"
 CHECK-NEXT:   },
 CHECK-NEXT:   "range": {
 CHECK-NEXT:     "end": {

--- a/nixd/tools/nixd/test/hover-options.md
+++ b/nixd/tools/nixd/test/hover-options.md
@@ -1,5 +1,5 @@
 # RUN: nixd --lit-test \
-# RUN: --nixos-options-expr="{ foo.bar = { _type = \"option\"; }; }" \
+# RUN: --nixos-options-expr="{ foo.bar = { _type = \"option\";  description = \"test\"; type.description = \"hello type\"; }; }" \
 # RUN: < %s | FileCheck %s
 
 
@@ -59,23 +59,24 @@
 ```
 
 ```
-     CHECK: "id": 2,
-CHECK-NEXT: "jsonrpc": "2.0",
-CHECK-NEXT: "result": {
-CHECK-NEXT:   "contents": {
-CHECK-NEXT:     "kind": "markdown",
-CHECK-NEXT:     "value": "? (missing type)"
-CHECK-NEXT:   },
-CHECK-NEXT:   "range": {
-CHECK-NEXT:     "end": {
-CHECK-NEXT:       "character": 9,
-CHECK-NEXT:       "line": 0
-CHECK-NEXT:     },
-CHECK-NEXT:     "start": {
-CHECK-NEXT:       "character": 6,
-CHECK-NEXT:       "line": 0
-CHECK-NEXT:     }
-CHECK-NEXT:   }
+     CHECK:  "id": 2,
+CHECK-NEXT:  "jsonrpc": "2.0",
+CHECK-NEXT:  "result": {
+CHECK-NEXT:    "contents": {
+CHECK-NEXT:      "kind": "markdown",
+CHECK-NEXT:      "value": " (hello type)\ntest"
+CHECK-NEXT:    },
+CHECK-NEXT:    "range": {
+CHECK-NEXT:      "end": {
+CHECK-NEXT:        "character": 9,
+CHECK-NEXT:        "line": 0
+CHECK-NEXT:      },
+CHECK-NEXT:      "start": {
+CHECK-NEXT:        "character": 6,
+CHECK-NEXT:        "line": 0
+CHECK-NEXT:      }
+CHECK-NEXT:    }
+CHECK-NEXT:  }
 ```
 
 ```json


### PR DESCRIPTION
Closes #174

This patch implements hover documentation for options. 