### PR TITLE
libnixf,nixd: demote livenss warning severity to "hint"

### DIFF
--- a/libnixf/include/nixf/Basic/Diagnostic.h
+++ b/libnixf/include/nixf/Basic/Diagnostic.h
@@ -149,11 +149,22 @@ public:
   /// should be "Fatal", "Error" or "Warning"
   /// this will affect the eval process.
   ///
-  /// "Fatal"   -- shouldn't eval the code, e.g. parsing error.
-  /// "Error"   -- trigger an error in nix, but we can recover & eval the code.
   /// "Warning" -- just a warning.
-  /// "Note"    -- some additional information about the error.
-  enum Severity { DS_Fatal, DS_Error, DS_Warning };
+  enum Severity {
+    /// shouldn't eval the code, e.g. parsing error.
+    DS_Fatal,
+    /// trigger an error in nix, but we can recover & eval the code.
+    DS_Error,
+    /// A warning.
+    DS_Warning,
+    /// An information.
+    DS_Info,
+
+    /// A hint. Hints are usually not rendered directly in some editor GUI
+    /// So this is suitable for liveness analysis results.
+    /// For example, "unused xxx"
+    DS_Hint,
+  };
 
   /// Internal kind
   enum DiagnosticKind {

--- a/libnixf/include/nixf/Basic/DiagnosticKinds.inc
+++ b/libnixf/include/nixf/Basic/DiagnosticKinds.inc
@@ -54,11 +54,11 @@ DIAG("sema-dup-formal-arg", DuplicatedFormalToArg, Error,
      "function argument duplicated to a function formal")
 DIAG("sema-undefined-variable", UndefinedVariable, Error,
      "undefined variable `{}`")
-DIAG("sema-def-not-used", DefinitionNotUsed, Warning,
+DIAG("sema-def-not-used", DefinitionNotUsed, Hint,
      "definition `{}` is not used")
-DIAG("sema-extra-rec", ExtraRecursive, Warning,
+DIAG("sema-extra-rec", ExtraRecursive, Hint,
      "attrset is not necessary to be `rec`ursive ")
-DIAG("sema-extra-with", ExtraWith, Warning, "unused `with` expression")
+DIAG("sema-extra-with", ExtraWith, Hint, "unused `with` expression")
 
 // let a = 1; b = { a = 2; }; with b;  a
 // "a" will bind to "let", not "with", that is not very intuitive.

--- a/nixd/lib/Controller/Convert.cpp
+++ b/nixd/lib/Controller/Convert.cpp
@@ -1,4 +1,5 @@
 #include "Convert.h"
+#include "nixf/Basic/Diagnostic.h"
 
 using namespace lspserver;
 
@@ -11,6 +12,10 @@ int getLSPSeverity(nixf::Diagnostic::DiagnosticKind Kind) {
     return 1;
   case nixf::Diagnostic::DS_Warning:
     return 2;
+  case nixf::Diagnostic::DS_Info:
+    return 3;
+  case nixf::Diagnostic::DS_Hint:
+    return 4;
   }
   assert(false && "Invalid severity");
   __builtin_unreachable();

--- a/nixd/tools/nixd/test/diagnostic-liveness-formal.md
+++ b/nixd/tools/nixd/test/diagnostic-liveness-formal.md
@@ -51,7 +51,7 @@ CHECK-NEXT:         "line": 0
 CHECK-NEXT:       }
 CHECK-NEXT:     },
 CHECK-NEXT:     "relatedInformation": [],
-CHECK-NEXT:     "severity": 2,
+CHECK-NEXT:     "severity": 4,
 CHECK-NEXT:     "source": "nixf",
 CHECK-NEXT:     "tags": [
 CHECK-NEXT:       1


### PR DESCRIPTION
<img width="258" alt="截屏2024-06-23 00 46 39" src="https://github.com/nix-community/nixd/assets/36667224/e90c48a1-172c-460a-856a-e4ff16f3933e">

After this patch nixd won't be very chatty if some variable is not used. I think this is a better approach in comparison to marking a "warning". Unused variables are generally not very harmful in Nix codes, and indeed developers may rely on it. Thus the severity of all liveness related warnings are demoted to "hint".