### PR TITLE
libnixf: disable escaping `with` warning for builtin

### DIFF
--- a/libnixf/src/Sema/VariableLookup.cpp
+++ b/libnixf/src/Sema/VariableLookup.cpp
@@ -81,7 +81,7 @@ void VariableLookupAnalysis::lookupVar(const ExprVar &Var,
     Def->usedBy(Var);
     Results.insert({&Var, LookupResult{LookupResultKind::Defined, Def}});
 
-    if (EnclosedWith) {
+    if (EnclosedWith && !Def->isBuiltin()) {
       // Escaping from "with" to outer scope.
       // https://github.com/NixOS/nix/issues/490
 

--- a/libnixf/test/Sema/VariableLookup.cpp
+++ b/libnixf/test/Sema/VariableLookup.cpp
@@ -270,6 +270,14 @@ TEST_F(VLATest, EscapingWith) {
   ASSERT_EQ(D.notes()[1].range().rCur().offset(), 7);
 }
 
+TEST_F(VLATest, EscapingWithButBuiltin) {
+  std::shared_ptr<Node> AST = parse("with { a = 1; }; [ a true false null ]", Diags);
+  VariableLookupAnalysis VLA(Diags);
+  VLA.runOnAST(*AST);
+  
+  ASSERT_EQ(Diags.size(), 0);
+}
+
 TEST_F(VLATest, InheritRec) {
   // Make sure inheirt (expr), the expression is binded to "NewEnv".
   std::shared_ptr<Node> AST =


### PR DESCRIPTION
Giving an "escaping with" warning to builtin variables like `true`, `false` or `null` is not very suitable:  

![image](https://github.com/nix-community/nixd/assets/29816865/daeb04ad-37a6-4f36-bf0f-81397e9a5725)
