### PR TITLE
libnixf/Sema: ignore builtin liveness warning

### DIFF
--- a/libnixf/src/Sema/VariableLookup.cpp
+++ b/libnixf/src/Sema/VariableLookup.cpp
@@ -48,6 +48,9 @@ void VariableLookupAnalysis::emitEnvLivenessWarning(
     // the lambda signature.
     if (Def->source() == Definition::DS_LambdaArg)
       continue;
+    // Ignore builtins usage.
+    if (!Def->syntax())
+      continue;
     if (Def->uses().empty()) {
       Diagnostic &D = Diags.emplace_back(Diagnostic::DK_DefinitionNotUsed,
                                          Def->syntax()->range());

--- a/libnixf/test/Sema/VariableLookup.cpp
+++ b/libnixf/test/Sema/VariableLookup.cpp
@@ -316,4 +316,17 @@ rec {
   ASSERT_EQ(Diags[0].range().lCur().line(), 3);
 }
 
+TEST_F(VLATest, Issue533) {
+  const char *Src = R"(
+let ;
+in 1
+  )";
+
+  std::shared_ptr<Node> AST = parse(Src, Diags);
+  VariableLookupAnalysis VLA(Diags);
+  VLA.runOnAST(*AST);
+
+  ASSERT_EQ(Diags.size(), 1);
+}
+
 } // namespace


### PR DESCRIPTION
let ... in ... expr may create pass-through environments to "emitLivenessWarning". However, this function does not consider the "builtin" scope. In this case, `Def->syntax()` will be nullptr and thus the server crashes.

Add the checking to "emitLivenessWarning" function.

Fixes: #533