### PR TITLE
nixd: don't pass `NIX_PATH` to nixd-attrset-eval unit tests

### DIFF
--- a/nixd/tools/nixd-attrset-eval/test/lit.cfg.py
+++ b/nixd/tools/nixd-attrset-eval/test/lit.cfg.py
@@ -12,8 +12,6 @@ test_root = os.path.dirname(__file__)
 
 build_dir = os.getenv('MESON_BUILD_ROOT', default = '/dev/null')
 
-config.environment['NIX_PATH'] = os.getenv('NIX_PATH')
-
 # test_source_root: The root path where tests are located.
 config.test_source_root = test_root
 


### PR DESCRIPTION
Fixes: #541 