### PR TITLE
nixd: `lib` + `pkgs` completion with "select", e.g. `lib.gen|`, `pkgs.stdenv.mkDerivat|`

### DIFF
--- a/nixd/include/nixd/Protocol/AttrSet.h
+++ b/nixd/include/nixd/Protocol/AttrSet.h
@@ -26,7 +26,13 @@ constexpr inline std::string_view Exit = "exit";
 using EvalExprParams = std::string;
 using EvalExprResponse = std::optional<std::string>;
 
-using AttrPathInfoParams = std::vector<std::string>;
+/// \brief A list of strings that "select"s into a attribute set.
+using Selector = std::vector<std::string>;
+
+using PackageInfoParams = Selector;
+using OptionInfoParams = Selector;
+
+using AttrPathInfoParams = Selector;
 
 struct PackageDescription {
   std::optional<std::string> Name;
@@ -45,7 +51,7 @@ bool fromJSON(const llvm::json::Value &Params, PackageDescription &R,
               llvm::json::Path P);
 
 struct AttrPathCompleteParams {
-  std::vector<std::string> Scope;
+  Selector Scope;
   /// \brief Search for packages prefixed with this "prefix"
   std::string Prefix;
 };

--- a/nixd/lib/Controller/AST.h
+++ b/nixd/lib/Controller/AST.h
@@ -1,10 +1,28 @@
 /// \file
 /// \brief This file declares some common analysis (tree walk) on the AST.
 
+#include "nixd/Protocol/AttrSet.h"
+
 #include <nixf/Sema/ParentMap.h>
 #include <nixf/Sema/VariableLookup.h>
 
 namespace nixd {
+
+namespace idioms {
+
+/// \brief Hardcoded name for "pkgs.xxx", or "with pkgs;"
+///
+/// Assume that the value of this variable have the same structure with `import
+/// nixpkgs {}
+constexpr inline std::string_view Pkgs = "pkgs";
+
+/// \brief Hardcoded name for nixpkgs "lib"
+///
+/// Assume that the value of this variable is "nixpkgs lib".
+/// e.g. lib.genAttrs.
+constexpr inline std::string_view Lib = "lib";
+
+} // namespace idioms
 
 /// \brief Search up until there are some node associated with "EnvNode".
 [[nodiscard]] const nixf::EnvNode *
@@ -28,6 +46,16 @@ upEnv(const nixf::Node &Desc, const nixf::VariableLookupAnalysis &VLA,
 /// Try to find these name as a pre-selected scope, the last value is "prefix".
 std::pair<std::vector<std::string>, std::string>
 getScopeAndPrefix(const nixf::Node &N, const nixf::ParentMapAnalysis &PM);
+
+/// \brief The attrpath has a dynamic name, thus it cannot be trivially
+/// transformed to "static" selector.
+struct DynamicNameException : std::exception {};
+
+/// \brief Construct a nixd::Selector from \p AP.
+Selector mkSelector(const nixf::AttrPath &AP, Selector BaseSelector);
+
+/// \brief Construct a nixd::Selector from \p Select.
+Selector mkSelector(const nixf::ExprSelect &Select, Selector BaseSelector);
 
 enum class FindAttrPathResult {
   OK,

--- a/nixd/tools/nixd/test/completion-select-lib.md
+++ b/nixd/tools/nixd/test/completion-select-lib.md
@@ -1,0 +1,77 @@
+# RUN: nixd --lit-test \
+# RUN: --nixpkgs-expr="{ lib.hello.meta.description = \"Very Nice\";  }" \
+# RUN: < %s | FileCheck %s
+
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "method":"textDocument/didOpen",
+   "params":{
+      "textDocument":{
+         "uri":"file:///completion.nix",
+         "languageId":"nix",
+         "version":1,
+         "text":"lib.hel"
+      }
+   }
+}
+```
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "textDocument/completion",
+    "params": {
+        "textDocument": {
+            "uri": "file:///completion.nix"
+        },
+        "position": {
+            "line": 0,
+            "character": 6
+        },
+        "context": {
+            "triggerKind": 1
+        }
+    }
+}
+```
+
+```
+     CHECK:    "isIncomplete": false,
+CHECK-NEXT:    "items": [
+CHECK-NEXT:      {
+CHECK-NEXT:        "data": "{\"Prefix\":\"hel\",\"Scope\":[\"lib\"]}",
+CHECK-NEXT:        "kind": 5,
+CHECK-NEXT:        "label": "hello",
+CHECK-NEXT:        "score": 0
+CHECK-NEXT:      }
+CHECK-NEXT:    ]
+```
+
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/completion-select.md
+++ b/nixd/tools/nixd/test/completion-select.md
@@ -1,0 +1,77 @@
+# RUN: nixd --lit-test \
+# RUN: --nixpkgs-expr="{ hello.meta.description = \"Very Nice\";  }" \
+# RUN: < %s | FileCheck %s
+
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "method":"textDocument/didOpen",
+   "params":{
+      "textDocument":{
+         "uri":"file:///completion.nix",
+         "languageId":"nix",
+         "version":1,
+         "text":"pkgs.hel"
+      }
+   }
+}
+```
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "textDocument/completion",
+    "params": {
+        "textDocument": {
+            "uri": "file:///completion.nix"
+        },
+        "position": {
+            "line": 0,
+            "character": 7
+        },
+        "context": {
+            "triggerKind": 1
+        }
+    }
+}
+```
+
+```
+     CHECK:    "isIncomplete": false,
+CHECK-NEXT:    "items": [
+CHECK-NEXT:      {
+CHECK-NEXT:        "data": "{\"Prefix\":\"hel\",\"Scope\":[]}",
+CHECK-NEXT:        "kind": 5,
+CHECK-NEXT:        "label": "hello",
+CHECK-NEXT:        "score": 0
+CHECK-NEXT:      }
+CHECK-NEXT:    ]
+```
+
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```


### PR DESCRIPTION
Fixes: #495 

![Screenshot_20240716_182427](https://github.com/user-attachments/assets/0d973dbd-a0e2-4c2d-ad76-d61f2bd4bc42)
