### PR TITLE
nixd/Controller: support "goto definition" for select expressions

### DIFF
--- a/nixd/lib/Controller/AST.cpp
+++ b/nixd/lib/Controller/AST.cpp
@@ -247,6 +247,19 @@ nixd::Selector nixd::mkSelector(const nixf::ExprSelect &Select,
   return BaseSelector;
 }
 
+nixd::Selector nixd::mkSelector(const nixf::ExprSelect &Sel,
+                                const nixf::VariableLookupAnalysis &VLA,
+                                const nixf::ParentMapAnalysis &PM) {
+  if (Sel.expr().kind() != Node::NK_ExprVar)
+    throw NotVariableSelect();
+
+  const auto &Var = static_cast<ExprVar &>(Sel.expr());
+
+  auto BaseSelector = mkIdiomSelector(Var, VLA, PM);
+
+  return mkSelector(Sel, std::move(BaseSelector));
+}
+
 std::pair<std::vector<std::string>, std::string>
 nixd::getScopeAndPrefix(const Node &N, const ParentMapAnalysis &PM) {
   if (N.kind() != Node::NK_Identifer)

--- a/nixd/lib/Controller/AST.h
+++ b/nixd/lib/Controller/AST.h
@@ -3,6 +3,7 @@
 
 #include "nixd/Protocol/AttrSet.h"
 
+#include <nixf/Basic/Nodes/Expr.h>
 #include <nixf/Sema/ParentMap.h>
 #include <nixf/Sema/VariableLookup.h>
 
@@ -49,6 +50,8 @@ upEnv(const nixf::Node &Desc, const nixf::VariableLookupAnalysis &VLA,
 std::pair<std::vector<std::string>, std::string>
 getScopeAndPrefix(const nixf::Node &N, const nixf::ParentMapAnalysis &PM);
 
+struct IdiomException : std::exception {};
+
 /// \brief Exceptions scoped in nixd::mkIdiomSelector
 struct IdiomSelectorException : std::exception {};
 
@@ -74,13 +77,17 @@ Selector mkIdiomSelector(const nixf::ExprVar &Var,
                          const nixf::VariableLookupAnalysis &VLA,
                          const nixf::ParentMapAnalysis &PM);
 
-struct SelectorException : std::exception {};
-
 /// \brief The attrpath has a dynamic name, thus it cannot be trivially
 /// transformed to "static" selector.
-struct DynamicNameException : SelectorException {
+struct DynamicNameException : IdiomSelectorException {
   [[nodiscard]] const char *what() const noexcept override {
     return "dynamic attribute path encountered";
+  }
+};
+
+struct NotVariableSelect : IdiomSelectorException {
+  [[nodiscard]] const char *what() const noexcept override {
+    return "the base expression of the select is not a variable";
   }
 };
 
@@ -89,6 +96,11 @@ Selector mkSelector(const nixf::AttrPath &AP, Selector BaseSelector);
 
 /// \brief Construct a nixd::Selector from \p Select.
 Selector mkSelector(const nixf::ExprSelect &Select, Selector BaseSelector);
+
+/// \brief Construct a nixd::Selector from \p Select.
+Selector mkSelector(const nixf::ExprSelect &Select,
+                    const nixf::VariableLookupAnalysis &VLA,
+                    const nixf::ParentMapAnalysis &PM);
 
 enum class FindAttrPathResult {
   OK,

--- a/nixd/lib/Controller/AST.h
+++ b/nixd/lib/Controller/AST.h
@@ -62,10 +62,18 @@ struct NotAnIdiomException : IdiomSelectorException {
   }
 };
 
+struct VLAException : std::exception {};
+
 /// \brief No such variable.
-struct NoSuchVarException : IdiomSelectorException {
+struct NoSuchVarException : VLAException {
   [[nodiscard]] const char *what() const noexcept override {
     return "no such variable";
+  }
+};
+
+struct UndefinedVarException : VLAException {
+  [[nodiscard]] const char *what() const noexcept override {
+    return "undefined variable";
   }
 };
 

--- a/nixd/lib/Controller/Completion.cpp
+++ b/nixd/lib/Controller/Completion.cpp
@@ -351,17 +351,11 @@ void completeSelect(const nixf::ExprSelect &Select, AttrSetClient &Client,
   // Ask nixpkgs provider to get idioms completion.
   NixpkgsCompletionProvider NCP(Client);
 
-  const auto Handler = [](std::exception &E) noexcept {
-    log(DBG "skipped, reason: {0}", E.what());
-  };
   try {
     Selector Sel = mkSelector(Select, mkIdiomSelector(Var, VLA, PM));
     NCP.completePackages(mkParams(Sel, IsComplete), List);
   } catch (IdiomSelectorException &E) {
-    Handler(E);
-    return;
-  } catch (SelectorException &E) {
-    Handler(E);
+    log(DBG "skipped, reason: {0}", E.what());
     return;
   }
 

--- a/nixd/lib/Controller/Completion.cpp
+++ b/nixd/lib/Controller/Completion.cpp
@@ -15,6 +15,7 @@
 
 #include <boost/asio/post.hpp>
 
+#include <exception>
 #include <semaphore>
 #include <set>
 #include <unordered_set>
@@ -318,9 +319,11 @@ void completeVarName(const VariableLookupAnalysis &VLA,
     // Invoke nixpkgs provider to get the completion list.
     // Variable names are always incomplete.
     NCP.completePackages(mkParams(Sel, /*IsComplete=*/false), List);
-  } catch (IdiomSelectorException &E) {
-    log(DBG "skipped, reason: {0}", E.what());
-    return;
+  } catch (ExceedSizeError &) {
+    // Let "onCompletion" catch this exception to set "inComplete" field.
+    throw;
+  } catch (std::exception &E) {
+    return log(DBG "skipped, reason: {0}", E.what());
   }
 
 #undef DBGPREFIX
@@ -354,9 +357,11 @@ void completeSelect(const nixf::ExprSelect &Select, AttrSetClient &Client,
   try {
     Selector Sel = mkSelector(Select, mkIdiomSelector(Var, VLA, PM));
     NCP.completePackages(mkParams(Sel, IsComplete), List);
-  } catch (IdiomSelectorException &E) {
-    log(DBG "skipped, reason: {0}", E.what());
-    return;
+  } catch (ExceedSizeError &) {
+    // Let "onCompletion" catch this exception to set "inComplete" field.
+    throw;
+  } catch (std::exception &E) {
+    return log(DBG "skipped, reason: {0}", E.what());
   }
 
 #undef DBGPREFIX

--- a/nixd/lib/Controller/Definition.h
+++ b/nixd/lib/Controller/Definition.h
@@ -7,9 +7,15 @@
 
 namespace nixd {
 
+struct CannotFindVarException : std::exception {
+  [[nodiscard]] const char *what() const noexcept override {
+    return "cannot find variable on given node";
+  }
+};
+
 /// \brief Heuristically find definition on some node
-llvm::Expected<const nixf::Definition &>
-findDefinition(const nixf::Node &N, const nixf::ParentMapAnalysis &PMA,
-               const nixf::VariableLookupAnalysis &VLA);
+const nixf::Definition &findDefinition(const nixf::Node &N,
+                                       const nixf::ParentMapAnalysis &PMA,
+                                       const nixf::VariableLookupAnalysis &VLA);
 
 } // namespace nixd

--- a/nixd/lib/Controller/DocumentHighlight.cpp
+++ b/nixd/lib/Controller/DocumentHighlight.cpp
@@ -9,10 +9,11 @@
 #include "nixd/Controller/Controller.h"
 
 #include <boost/asio/post.hpp>
-#include <exception>
 #include <lspserver/Protocol.h>
 #include <nixf/Sema/ParentMap.h>
 #include <nixf/Sema/VariableLookup.h>
+
+#include <exception>
 
 using namespace lspserver;
 using namespace nixd;

--- a/nixd/lib/Controller/DocumentHighlight.cpp
+++ b/nixd/lib/Controller/DocumentHighlight.cpp
@@ -9,6 +9,7 @@
 #include "nixd/Controller/Controller.h"
 
 #include <boost/asio/post.hpp>
+#include <exception>
 #include <lspserver/Protocol.h>
 #include <nixf/Sema/ParentMap.h>
 #include <nixf/Sema/VariableLookup.h>
@@ -19,30 +20,34 @@ using namespace llvm;
 using namespace nixf;
 
 namespace {
-Error highlight(const nixf::Node &Desc, const ParentMapAnalysis &PMA,
-                const VariableLookupAnalysis &VLA, const URIForFile &URI,
-                std::vector<DocumentHighlight> &Highlights) {
+
+std::vector<DocumentHighlight> highlight(const nixf::Node &Desc,
+                                         const ParentMapAnalysis &PMA,
+                                         const VariableLookupAnalysis &VLA,
+                                         const URIForFile &URI) {
   // Find "definition"
-  if (auto Def = findDefinition(Desc, PMA, VLA)) {
-    // OK, iterate all uses.
-    for (const auto *Use : Def->uses()) {
-      assert(Use);
-      Highlights.emplace_back(DocumentHighlight{
-          .range = toLSPRange(Use->range()),
-          .kind = DocumentHighlightKind::Read,
-      });
-    }
-    if (Def->syntax()) {
-      const Node &Syntax = *Def->syntax();
-      Highlights.emplace_back(DocumentHighlight{
-          .range = toLSPRange(Syntax.range()),
-          .kind = DocumentHighlightKind::Write,
-      });
-    }
-    return Error::success();
+  auto Def = findDefinition(Desc, PMA, VLA);
+
+  std::vector<DocumentHighlight> Highlights;
+  // OK, iterate all uses.
+  for (const auto *Use : Def.uses()) {
+    assert(Use);
+    Highlights.emplace_back(DocumentHighlight{
+        .range = toLSPRange(Use->range()),
+        .kind = DocumentHighlightKind::Read,
+    });
   }
-  return error("Cannot find definition of this node");
+  if (Def.syntax()) {
+    const Node &Syntax = *Def.syntax();
+    Highlights.emplace_back(DocumentHighlight{
+        .range = toLSPRange(Syntax.range()),
+        .kind = DocumentHighlightKind::Write,
+    });
+  }
+
+  return Highlights;
 }
+
 } // namespace
 
 void Controller::onDocumentHighlight(
@@ -58,20 +63,14 @@ void Controller::onDocumentHighlight(
           Reply(error("cannot find corresponding node on given position"));
           return;
         }
-        std::vector<DocumentHighlight> Highlights;
-        if (auto Err = highlight(*Desc, *TU->parentMap(), *TU->variableLookup(),
-                                 URI, Highlights)) {
-          // FIXME: Empty response if there are no def-use chain found.
-          // For document highlights, the specification explicitly specified LSP
-          // should do "fuzzy" things.
-
-          // Empty response on error, don't reply all errors because this method
-          // is very frequently called.
-          Reply(std::vector<DocumentHighlight>{});
-          lspserver::elog("textDocument/documentHighlight failed: {0}", Err);
-          return;
+        try {
+          const auto &PM = *TU->parentMap();
+          const auto &VLA = *TU->variableLookup();
+          return Reply(highlight(*Desc, PM, VLA, URI));
+        } catch (std::exception &E) {
+          elog("textDocument/documentHighlight failed: {0}", E.what());
+          return Reply(std::vector<DocumentHighlight>{});
         }
-        Reply(std::move(Highlights));
       }
     }
   };

--- a/nixd/tools/nixd/test/definition/package.md
+++ b/nixd/tools/nixd/test/definition/package.md
@@ -62,19 +62,6 @@ CHECK-NEXT: "result": [
 CHECK-NEXT:   {
 CHECK-NEXT:     "range": {
 CHECK-NEXT:       "end": {
-CHECK-NEXT:         "character": 0,
-CHECK-NEXT:         "line": 33
-CHECK-NEXT:       },
-CHECK-NEXT:       "start": {
-CHECK-NEXT:         "character": 0,
-CHECK-NEXT:         "line": 33
-CHECK-NEXT:       }
-CHECK-NEXT:     },
-CHECK-NEXT:     "uri": "file:///foo"
-CHECK-NEXT:   },
-CHECK-NEXT:   {
-CHECK-NEXT:     "range": {
-CHECK-NEXT:       "end": {
 CHECK-NEXT:         "character": 4,
 CHECK-NEXT:         "line": 0
 CHECK-NEXT:       },
@@ -84,6 +71,19 @@ CHECK-NEXT:         "line": 0
 CHECK-NEXT:       }
 CHECK-NEXT:     },
 CHECK-NEXT:     "uri": "file:///basic.nix"
+CHECK-NEXT:   },
+CHECK-NEXT:   {
+CHECK-NEXT:     "range": {
+CHECK-NEXT:       "end": {
+CHECK-NEXT:         "character": 0,
+CHECK-NEXT:         "line": 33
+CHECK-NEXT:       },
+CHECK-NEXT:       "start": {
+CHECK-NEXT:         "character": 0,
+CHECK-NEXT:         "line": 33
+CHECK-NEXT:       }
+CHECK-NEXT:     },
+CHECK-NEXT:     "uri": "file:///foo"
 CHECK-NEXT:   }
 ```
 

--- a/nixd/tools/nixd/test/definition/select-package-with.md
+++ b/nixd/tools/nixd/test/definition/select-package-with.md
@@ -1,0 +1,82 @@
+# RUN: nixd --nixpkgs-expr="{ x.y.meta.position = \"/foo:33\"; }" --lit-test < %s | FileCheck %s
+
+Similar to [package.md](./package.md), but testing that we can do "selection" + "with".
+i.e. testing if `with pkgs; [x.y]` works.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```json
+{
+   "jsonrpc":"2.0",
+   "method":"textDocument/didOpen",
+   "params":{
+      "textDocument":{
+         "uri":"file:///basic.nix",
+         "languageId":"nix",
+         "version":1,
+         "text":"with pkgs; [x.y]"
+      }
+   }
+}
+```
+
+<-- textDocument/definition(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/definition",
+   "params":{
+      "textDocument":{
+         "uri":"file:///basic.nix"
+      },
+      "position":{
+        "line": 0,
+        "character":15
+      }
+   }
+}
+```
+
+```
+     CHECK: "id": 2,
+CHECK-NEXT: "jsonrpc": "2.0",
+CHECK-NEXT: "result": {
+CHECK-NEXT:     "range": {
+CHECK-NEXT:       "end": {
+CHECK-NEXT:         "character": 0,
+CHECK-NEXT:         "line": 33
+CHECK-NEXT:       },
+CHECK-NEXT:       "start": {
+CHECK-NEXT:         "character": 0,
+CHECK-NEXT:         "line": 33
+CHECK-NEXT:       }
+CHECK-NEXT:     },
+CHECK-NEXT:     "uri": "file:///foo"
+CHECK-NEXT:   }
+```
+
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/definition/select-package.md
+++ b/nixd/tools/nixd/test/definition/select-package.md
@@ -1,0 +1,82 @@
+# RUN: nixd --nixpkgs-expr="{ x.meta.position = \"/foo:33\"; }" --lit-test < %s | FileCheck %s
+
+Similar to [package.md](./package.md), but testing that we can do "selection".
+i.e. testing if `pkgs.x` works.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```json
+{
+   "jsonrpc":"2.0",
+   "method":"textDocument/didOpen",
+   "params":{
+      "textDocument":{
+         "uri":"file:///basic.nix",
+         "languageId":"nix",
+         "version":1,
+         "text":"pkgs.x"
+      }
+   }
+}
+```
+
+<-- textDocument/definition(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/definition",
+   "params":{
+      "textDocument":{
+         "uri":"file:///basic.nix"
+      },
+      "position":{
+        "line": 0,
+        "character":5
+      }
+   }
+}
+```
+
+```
+     CHECK: "id": 2,
+CHECK-NEXT: "jsonrpc": "2.0",
+CHECK-NEXT: "result": {
+CHECK-NEXT:     "range": {
+CHECK-NEXT:       "end": {
+CHECK-NEXT:         "character": 0,
+CHECK-NEXT:         "line": 33
+CHECK-NEXT:       },
+CHECK-NEXT:       "start": {
+CHECK-NEXT:         "character": 0,
+CHECK-NEXT:         "line": 33
+CHECK-NEXT:       }
+CHECK-NEXT:     },
+CHECK-NEXT:     "uri": "file:///foo"
+CHECK-NEXT:   }
+```
+
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/rename/duplicated.md
+++ b/nixd/tools/nixd/test/rename/duplicated.md
@@ -61,7 +61,7 @@
 ```
      CHECK: "error": {
 CHECK-NEXT:   "code": -32001,
-CHECK-NEXT:   "message": "this varaible is not used in var lookup (duplicated attr?)"
+CHECK-NEXT:   "message": "no such variable"
 CHECK-NEXT: },
 CHECK-NEXT: "id": 2,
 CHECK-NEXT: "jsonrpc": "2.0"

--- a/nixd/tools/nixd/test/rename/with.md
+++ b/nixd/tools/nixd/test/rename/with.md
@@ -58,7 +58,7 @@
 ```
 
 ```
-     CHECK:   "message": "cannot rename `with` defined variables"
+     CHECK:   "message": "cannot rename `with` defined variable"
 CHECK-NEXT: },
 CHECK-NEXT: "id": 2,
 CHECK-NEXT: "jsonrpc": "2.0"


### PR DESCRIPTION
Add "goto definition" support for select expressions, e.g.

```nix
with pkgs; [
  nixVersions.nix
#              ^
]
```

```nix
pkgs.stdenv.mkDerivation
#            ^
```

These values are now "Ctrl + Click"-able to nixpkgs locations.