### PR TITLE
nixd/Controller: support completion for `pkgs.subpackages`

### DIFF
--- a/nixd/lib/Controller/AST.h
+++ b/nixd/lib/Controller/AST.h
@@ -25,31 +25,6 @@ constexpr inline std::string_view Pkgs = "pkgs";
 /// e.g. lib.genAttrs.
 constexpr inline std::string_view Lib = "lib";
 
-} // namespace idioms
-
-/// \brief Search up until there are some node associated with "EnvNode".
-[[nodiscard]] const nixf::EnvNode *
-upEnv(const nixf::Node &Desc, const nixf::VariableLookupAnalysis &VLA,
-      const nixf::ParentMapAnalysis &PM);
-
-/// \brief Determine whether or not some node has enclosed "with pkgs; [ ]"
-///
-/// Yes, this evaluation isn't flawless. What if the identifier isn't "pkgs"? We
-/// can't dynamically evaluate everything each time and invalidate them
-/// immediately after document updates. Therefore, this heuristic method
-/// represents a trade-off between performance considerations.
-[[nodiscard]] bool havePackageScope(const nixf::Node &N,
-                                    const nixf::VariableLookupAnalysis &VLA,
-                                    const nixf::ParentMapAnalysis &PM);
-
-/// \brief get variable scope, and it's prefix name.
-///
-/// Nixpkgs has some packages scoped in "nested" attrs.
-/// e.g. llvmPackages, pythonPackages.
-/// Try to find these name as a pre-selected scope, the last value is "prefix".
-std::pair<std::vector<std::string>, std::string>
-getScopeAndPrefix(const nixf::Node &N, const nixf::ParentMapAnalysis &PM);
-
 struct IdiomException : std::exception {};
 
 /// \brief Exceptions scoped in nixd::mkIdiomSelector
@@ -81,9 +56,9 @@ struct UndefinedVarException : VLAException {
 ///
 /// Try to heuristically find a selector of a variable, based on some known
 /// idioms.
-Selector mkIdiomSelector(const nixf::ExprVar &Var,
-                         const nixf::VariableLookupAnalysis &VLA,
-                         const nixf::ParentMapAnalysis &PM);
+Selector mkVarSelector(const nixf::ExprVar &Var,
+                       const nixf::VariableLookupAnalysis &VLA,
+                       const nixf::ParentMapAnalysis &PM);
 
 /// \brief The attrpath has a dynamic name, thus it cannot be trivially
 /// transformed to "static" selector.
@@ -109,6 +84,31 @@ Selector mkSelector(const nixf::ExprSelect &Select, Selector BaseSelector);
 Selector mkSelector(const nixf::ExprSelect &Select,
                     const nixf::VariableLookupAnalysis &VLA,
                     const nixf::ParentMapAnalysis &PM);
+
+} // namespace idioms
+
+/// \brief Search up until there are some node associated with "EnvNode".
+[[nodiscard]] const nixf::EnvNode *
+upEnv(const nixf::Node &Desc, const nixf::VariableLookupAnalysis &VLA,
+      const nixf::ParentMapAnalysis &PM);
+
+/// \brief Determine whether or not some node has enclosed "with pkgs; [ ]"
+///
+/// Yes, this evaluation isn't flawless. What if the identifier isn't "pkgs"? We
+/// can't dynamically evaluate everything each time and invalidate them
+/// immediately after document updates. Therefore, this heuristic method
+/// represents a trade-off between performance considerations.
+[[nodiscard]] bool havePackageScope(const nixf::Node &N,
+                                    const nixf::VariableLookupAnalysis &VLA,
+                                    const nixf::ParentMapAnalysis &PM);
+
+/// \brief get variable scope, and it's prefix name.
+///
+/// Nixpkgs has some packages scoped in "nested" attrs.
+/// e.g. llvmPackages, pythonPackages.
+/// Try to find these name as a pre-selected scope, the last value is "prefix".
+std::pair<std::vector<std::string>, std::string>
+getScopeAndPrefix(const nixf::Node &N, const nixf::ParentMapAnalysis &PM);
 
 enum class FindAttrPathResult {
   OK,

--- a/nixd/lib/Controller/Completion.cpp
+++ b/nixd/lib/Controller/Completion.cpp
@@ -313,7 +313,7 @@ void completeVarName(const VariableLookupAnalysis &VLA,
 
   // Try to complete the name by known idioms.
   try {
-    Selector Sel = mkIdiomSelector(N, VLA, PM);
+    Selector Sel = idioms::mkVarSelector(N, VLA, PM);
 
     // Clickling "pkgs" does not make sense for variable completion
     if (Sel.empty())
@@ -359,7 +359,8 @@ void completeSelect(const nixf::ExprSelect &Select, AttrSetClient &Client,
   NixpkgsCompletionProvider NCP(Client);
 
   try {
-    Selector Sel = mkSelector(Select, mkIdiomSelector(Var, VLA, PM));
+    Selector Sel =
+        idioms::mkSelector(Select, idioms::mkVarSelector(Var, VLA, PM));
     NCP.completePackages(mkParams(Sel, IsComplete), List);
   } catch (ExceedSizeError &) {
     // Let "onCompletion" catch this exception to set "inComplete" field.

--- a/nixd/lib/Controller/Definition.cpp
+++ b/nixd/lib/Controller/Definition.cpp
@@ -27,6 +27,7 @@
 #include <semaphore>
 
 using namespace nixd;
+using namespace nixd::idioms;
 using namespace nixf;
 using namespace lspserver;
 using namespace llvm;
@@ -298,7 +299,7 @@ Locations defineVar(const ExprVar &Var, const VariableLookupAnalysis &VLA,
 
     // Nixpkgs locations.
     try {
-      Selector Sel = mkIdiomSelector(Var, VLA, PM);
+      Selector Sel = mkVarSelector(Var, VLA, PM);
       Locations NixpkgsLocs = defineNixpkgsSelector(Sel, NixpkgsClient);
       return mergeVec(std::move(StaticLocs), NixpkgsLocs);
     } catch (std::exception &E) {

--- a/nixd/tools/nixd/test/completion/with-expr-select.md
+++ b/nixd/tools/nixd/test/completion/with-expr-select.md
@@ -1,0 +1,71 @@
+# RUN: nixd --nixpkgs-expr='{ ax.bx = 1; ax.by = 2; }' --lit-test < %s | FileCheck %s
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "method":"textDocument/didOpen",
+   "params":{
+      "textDocument":{
+         "uri":"file:///completion.nix",
+         "languageId":"nix",
+         "version":1,
+         "text":"with pkgs.ax; [ b ]"
+      }
+   }
+}
+```
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "textDocument/completion",
+    "params": {
+        "textDocument": {
+            "uri": "file:///completion.nix"
+        },
+        "position": {
+            "line": 0,
+            "character": 16
+        },
+        "context": {
+            "triggerKind": 1
+        }
+    }
+}
+```
+
+```
+     CHECK:    "data": "{\"Prefix\":\"b\",\"Scope\":[\"ax\"]}",
+CHECK-NEXT:    "kind": 5,
+CHECK-NEXT:    "label": "bx",
+CHECK-NEXT:    "score": 0
+CHECK-NEXT:  },
+CHECK-NEXT:  {
+CHECK-NEXT:    "data": "{\"Prefix\":\"b\",\"Scope\":[\"ax\"]}",
+CHECK-NEXT:    "kind": 5,
+CHECK-NEXT:    "label": "by",
+CHECK-NEXT:    "score": 0
+CHECK-NEXT:  }
+```


### PR DESCRIPTION
Fixes: #555

Add auto-completion code-snippet like this:

```nix
    with pkgs.vimPlugins; [
        |
    ]
```

i.e. with a "select" expression.

![Screenshot_20240731_211203](https://github.com/user-attachments/assets/7532baca-e20b-45bf-a44f-0270da5be1fb)
