### PR TITLE
libnixf: change extra-{rec,with},escaping-with diagnostics to warning

### DIFF
--- a/libnixf/src/Basic/diagnostic.py
+++ b/libnixf/src/Basic/diagnostic.py
@@ -192,19 +192,19 @@ diagnostics: list[Diagnostic] = [
     {
         "sname": "sema-extra-rec",
         "cname": "ExtraRecursive",
-        "severity": "Hint",
+        "severity": "Warning",
         "message": "attrset is not necessary to be `rec`ursive",
     },
     {
         "sname": "sema-extra-with",
         "cname": "ExtraWith",
-        "severity": "Hint",
+        "severity": "Warning",
         "message": "unused `with` expression",
     },
     {
         "sname": "sema-escaping-with",
         "cname": "EscapingWith",
-        "severity": "Hint",
+        "severity": "Warning",
         "message": "this variable comes from the scope outside of the `with` expression",
     },
 ]

--- a/libnixf/src/Basic/diagnostic.py
+++ b/libnixf/src/Basic/diagnostic.py
@@ -204,7 +204,7 @@ diagnostics: list[Diagnostic] = [
     {
         "sname": "sema-escaping-with",
         "cname": "EscapingWith",
-        "severity": "Warning",
+        "severity": "Hint",
         "message": "this variable comes from the scope outside of the `with` expression",
     },
 ]


### PR DESCRIPTION
Because if you don’t remove such unnecessary patterns in time, you may make subtle mistakes later