### PR TITLE
nixd/Controller: allow setting initial configuration via CLI

### DIFF
--- a/nixd/include/nixd/CommandLine/Configuration.h
+++ b/nixd/include/nixd/CommandLine/Configuration.h
@@ -1,0 +1,11 @@
+/// \file
+/// \brief Allow default configuration being passed via CLI
+
+#include "nixd/Controller/Configuration.h"
+
+namespace nixd {
+
+/// \brief Parse the CLI flag and initialize the config nixd::DefaultConfig
+nixd::Configuration parseCLIConfig();
+
+} // namespace nixd

--- a/nixd/include/nixd/CommandLine/Configuration.h
+++ b/nixd/include/nixd/CommandLine/Configuration.h
@@ -3,6 +3,8 @@
 
 #include "nixd/Controller/Configuration.h"
 
+#include <exception>
+
 namespace nixd {
 
 /// \brief Parse the CLI flag and initialize the config nixd::DefaultConfig

--- a/nixd/include/nixd/Support/Exception.h
+++ b/nixd/include/nixd/Support/Exception.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <llvm/Support/Error.h>
+
+#include <exception>
+
+namespace nixd {
+
+class LLVMErrorException : public std::exception {
+  llvm::Error E;
+
+public:
+  LLVMErrorException(llvm::Error E) : E(std::move(E)) {}
+
+  llvm::Error takeError() { return std::move(E); }
+};
+
+} // namespace nixd

--- a/nixd/include/nixd/Support/JSON.h
+++ b/nixd/include/nixd/Support/JSON.h
@@ -1,0 +1,38 @@
+#include "Exception.h"
+
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/JSON.h>
+
+#include <exception>
+
+namespace nixd {
+
+class JSONParseException : public LLVMErrorException {
+public:
+  JSONParseException(llvm::Error E) : LLVMErrorException(std::move(E)) {}
+
+  [[nodiscard]] const char *what() const noexcept override {
+    return "JSON result cannot be parsed";
+  }
+};
+
+class JSONSchemaException : public LLVMErrorException {
+public:
+  JSONSchemaException(llvm::Error E) : LLVMErrorException(std::move(E)) {}
+
+  [[nodiscard]] const char *what() const noexcept override {
+    return "JSON schema mismatch";
+  }
+};
+
+llvm::json::Value parse(llvm::StringRef JSON);
+
+template <class T> T fromJSON(const llvm::json::Value &V) {
+  llvm::json::Path::Root R;
+  T Result;
+  if (!fromJSON(V, Result, R))
+    throw JSONSchemaException(R.getError());
+  return Result;
+}
+
+} // namespace nixd

--- a/nixd/lib/CommandLine/Configuration.cpp
+++ b/nixd/lib/CommandLine/Configuration.cpp
@@ -4,6 +4,7 @@
 #include "nixd/CommandLine/Configuration.h"
 #include "nixd/CommandLine/Options.h"
 #include "nixd/Controller/Configuration.h"
+#include "nixd/Support/JSON.h"
 
 #include "lspserver/Logger.h"
 
@@ -28,23 +29,5 @@ Configuration nixd::parseCLIConfig() {
   if (DefaultConfigJSON.empty())
     return {};
 
-  llvm::Expected<llvm::json::Value> V = llvm::json::parse(DefaultConfigJSON);
-
-  if (!V) {
-    llvm::errs()
-        << "The JSON string of default configuration cannot be parsed, reason: "
-        << V.takeError() << "\n";
-    std::exit(-1);
-  }
-
-  llvm::json::Path::Root R;
-  Configuration C;
-  if (!fromJSON(*V, C, R)) {
-    // JSON is valid, but it has incorrect schema
-    llvm::errs()
-        << "The JSON string of default configuration has invalid schema: "
-        << R.getError() << "\n";
-    std::exit(-1);
-  }
-  return C;
+  return nixd::fromJSON<Configuration>(nixd::parse(DefaultConfigJSON));
 }

--- a/nixd/lib/CommandLine/Configuration.cpp
+++ b/nixd/lib/CommandLine/Configuration.cpp
@@ -1,0 +1,50 @@
+/// \file
+/// \brief This file implements CLI initialized configuration.
+
+#include "nixd/CommandLine/Configuration.h"
+#include "nixd/CommandLine/Options.h"
+#include "nixd/Controller/Configuration.h"
+
+#include "lspserver/Logger.h"
+
+#include <llvm/Support/CommandLine.h>
+#include <llvm/Support/JSON.h>
+
+#include <iostream>
+#include <string>
+
+using namespace nixd;
+using namespace llvm::cl;
+
+namespace {
+
+opt<std::string> DefaultConfigJSON{"config",
+                                   desc("JSON-encoded initial configuration"),
+                                   init(""), cat(NixdCategory)};
+
+} // namespace
+
+Configuration nixd::parseCLIConfig() {
+  if (DefaultConfigJSON.empty())
+    return {};
+
+  llvm::Expected<llvm::json::Value> V = llvm::json::parse(DefaultConfigJSON);
+
+  if (!V) {
+    llvm::errs()
+        << "The JSON string of default configuration cannot be parsed, reason: "
+        << V.takeError() << "\n";
+    std::exit(-1);
+  }
+
+  llvm::json::Path::Root R;
+  Configuration C;
+  if (!fromJSON(*V, C, R)) {
+    // JSON is valid, but it has incorrect schema
+    llvm::errs()
+        << "The JSON string of default configuration has invalid schema: "
+        << R.getError() << "\n";
+    std::exit(-1);
+  }
+  return C;
+}

--- a/nixd/lib/CommandLine/Configuration.cpp
+++ b/nixd/lib/CommandLine/Configuration.cpp
@@ -11,7 +11,6 @@
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/JSON.h>
 
-#include <iostream>
 #include <string>
 
 using namespace nixd;

--- a/nixd/lib/Controller/LifeTime.cpp
+++ b/nixd/lib/Controller/LifeTime.cpp
@@ -188,7 +188,8 @@ void Controller::
   try {
     Config = parseCLIConfig();
   } catch (LLVMErrorException &Err) {
-    lspserver::elog("parse CLI config error: {0}, {1}", Err.what(), Err.takeError());
+    lspserver::elog("parse CLI config error: {0}, {1}", Err.what(),
+                    Err.takeError());
     std::exit(-1);
   }
   fetchConfig();

--- a/nixd/lib/Controller/LifeTime.cpp
+++ b/nixd/lib/Controller/LifeTime.cpp
@@ -5,6 +5,7 @@
 
 #include "nixd-config.h"
 
+#include "nixd/CommandLine/Configuration.h"
 #include "nixd/CommandLine/Options.h"
 #include "nixd/Controller/Controller.h"
 #include "nixd/Eval/Launch.h"
@@ -183,6 +184,7 @@ void Controller::
       evalExprWithProgress(*Client, getDefaultNixOSOptionsExpr(),
                            "nixos options");
   }
+  Config = parseCLIConfig();
   fetchConfig();
 }
 

--- a/nixd/lib/Controller/LifeTime.cpp
+++ b/nixd/lib/Controller/LifeTime.cpp
@@ -188,7 +188,7 @@ void Controller::
   try {
     Config = parseCLIConfig();
   } catch (LLVMErrorException &Err) {
-    lspserver::elog("{0}, reason: {1}", Err.what(), Err.takeError());
+    lspserver::elog("parse CLI config error: {0}, {1}", Err.what(), Err.takeError());
     std::exit(-1);
   }
   fetchConfig();

--- a/nixd/lib/Controller/LifeTime.cpp
+++ b/nixd/lib/Controller/LifeTime.cpp
@@ -11,6 +11,7 @@
 #include "nixd/Eval/Launch.h"
 
 #include "lspserver/Protocol.h"
+#include "nixd/Support/Exception.h"
 
 #include <llvm/Support/CommandLine.h>
 
@@ -184,7 +185,12 @@ void Controller::
       evalExprWithProgress(*Client, getDefaultNixOSOptionsExpr(),
                            "nixos options");
   }
-  Config = parseCLIConfig();
+  try {
+    Config = parseCLIConfig();
+  } catch (LLVMErrorException &Err) {
+    lspserver::elog("{0}, reason: {1}", Err.what(), Err.takeError());
+    std::exit(-1);
+  }
   fetchConfig();
 }
 

--- a/nixd/lib/Controller/LifeTime.cpp
+++ b/nixd/lib/Controller/LifeTime.cpp
@@ -9,9 +9,9 @@
 #include "nixd/CommandLine/Options.h"
 #include "nixd/Controller/Controller.h"
 #include "nixd/Eval/Launch.h"
+#include "nixd/Support/Exception.h"
 
 #include "lspserver/Protocol.h"
-#include "nixd/Support/Exception.h"
 
 #include <llvm/Support/CommandLine.h>
 

--- a/nixd/lib/Support/JSON.cpp
+++ b/nixd/lib/Support/JSON.cpp
@@ -1,0 +1,10 @@
+#include "nixd/Support/JSON.h"
+
+#include <llvm/ADT/StringRef.h>
+
+llvm::json::Value nixd::parse(llvm::StringRef JSON) {
+  llvm::Expected<llvm::json::Value> E = llvm::json::parse(JSON);
+  if (!E)
+    throw JSONParseException(E.takeError());
+  return *E;
+}

--- a/nixd/lib/meson.build
+++ b/nixd/lib/meson.build
@@ -34,6 +34,7 @@ libnixd_lib = library(
     'Support/AutoCloseFD.cpp',
     'Support/AutoRemoveShm.cpp',
     'Support/ForkPiped.cpp',
+    'Support/JSON.cpp',
     'Support/StreamProc.cpp',
     dependencies: libnixd_deps,
     include_directories: libnixd_include,

--- a/nixd/lib/meson.build
+++ b/nixd/lib/meson.build
@@ -4,6 +4,7 @@ libnixd_deps = [ nixd_lsp_server, nixf, llvm, nixt ]
 
 libnixd_lib = library(
     'nixd',
+    'CommandLine/Configuration.cpp',
     'CommandLine/Options.cpp',
     'Controller/AST.cpp',
     'Controller/CodeAction.cpp',

--- a/nixd/tools/nixd/test/format/format.md
+++ b/nixd/tools/nixd/test/format/format.md
@@ -1,0 +1,62 @@
+# RUN: nixd --lit-test -config='{ "formatting": { "command": ["%S/nixfmt"] } }' < %s | FileCheck %s
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+```json
+{
+   "jsonrpc":"2.0",
+   "method":"textDocument/didOpen",
+   "params":{
+      "textDocument":{
+         "uri":"file:///format.nix",
+         "languageId":"nix",
+         "version":1,
+         "text":"{ stdenv,\npkgs}: \n let x=1; in { y = x; }"
+      }
+   }
+}
+```
+
+<-- textDocument/formatting
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "textDocument/formatting",
+    "params": {
+        "textDocument": {
+            "uri": "file:///format.nix"
+        },
+        "options": {
+            "tabSize": 2,
+            "insertSpaces": true,
+            "trimTrailingWhitespace": true,
+            "insertFinalNewline": true
+        }
+    }
+}
+```
+
+```
+CHECK: "newText": "Hello\n",
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/format/nixfmt
+++ b/nixd/tools/nixd/test/format/nixfmt
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "Hello"


### PR DESCRIPTION
Add a CLI flag `-config` used to set initial configuration. For editor clients which does not support workspace configuration, the flag could be used as a fallback.