### PR TITLE
nixd/Controller: Conditionally include devenv option support by default

### DIFF
--- a/nixd/lib/Controller/LifeTime.cpp
+++ b/nixd/lib/Controller/LifeTime.cpp
@@ -45,9 +45,10 @@ opt<std::string> DefaultDevenvOptionsExpr{
          "  flake = builtins.getFlake \"github:cachix/devenv\";\n"
          "in\n"
          "  if builtins.hasAttr currentSystem flake.outputs.packages\n"
-         "  then flake.outputs.packages.${currentSystem}.devenv-module-options.options\n"
-         "  else {}")
-};
+         "  then "
+         "flake.outputs.packages.${currentSystem}.devenv-module-options."
+         "options\n"
+         "  else {}")};
 
 opt<bool> EnableSemanticTokens{"semantic-tokens",
                                desc("Enable/Disable semantic tokens"),
@@ -63,7 +64,7 @@ std::string getDefaultNixpkgsExpr() {
 
 // Check if devenv executable is present
 bool isDevenvAvailable() {
-    return std::system("which devenv > /dev/null 2>&1") == 0;
+  return std::system("which devenv > /dev/null 2>&1") == 0;
 }
 
 std::string getDefaultDevenvOptionsExpr() {
@@ -220,15 +221,15 @@ void Controller::
 
   // Launch devenv worker only if devenv is available
   if (isDevenvAvailable()) {
-      std::lock_guard _(OptionsLock);
-      startOption("devenv", Options["devenv"]);
+    std::lock_guard _(OptionsLock);
+    startOption("devenv", Options["devenv"]);
 
-      if (AttrSetClient *Client = Options["devenv"]->client()) {
-          evalExprWithProgress(*Client, getDefaultDevenvOptionsExpr(),
-                              "devenv options");
-      }
+    if (AttrSetClient *Client = Options["devenv"]->client()) {
+      evalExprWithProgress(*Client, getDefaultDevenvOptionsExpr(),
+                           "devenv options");
+    }
   } else {
-      lspserver::log("devenv not found, skipping devenv initialization");
+    lspserver::log("devenv not found, skipping devenv initialization");
   }
 
   fetchConfig();

--- a/nixd/lib/Controller/LifeTime.cpp
+++ b/nixd/lib/Controller/LifeTime.cpp
@@ -42,7 +42,7 @@ opt<std::string> DefaultDevenvOptionsExpr{
     cat(NixdCategory),
     init("let\n"
          "  currentSystem = builtins.currentSystem;\n"
-         "  flake = builtins.getFlake \"github:cachix/devenv?ref=work/keys/expose-devenv-options\";\n"
+         "  flake = builtins.getFlake \"github:cachix/devenv\";\n"
          "in\n"
          "  if builtins.hasAttr currentSystem flake.outputs.packages\n"
          "  then flake.outputs.packages.${currentSystem}.devenv-module-options.options\n"


### PR DESCRIPTION
This PR adds default support for devenv.sh with the `nixd` LSP, eliminating the need for manual configuration. This enhancement makes `devenv` more intuitive and is likely to promote wider adoption of `nixd`, `devenv`, and `Nix` in general. Specifically this PR does the following things:
1: Fetch `devenv's` option using the `devenv-module-options` from the flake at https://github.com/cachix/devenv
2: Checks whether the devenv executable is present, if it is not it won't include the worker for options. 
3: Loads the LSP in case of `devenv` executable being present.

Requires: https://github.com/cachix/devenv/pull/1390 to be merged