### PR TITLE
nixd/docs/editors: add markdown parsers in nvim-lsp

### DIFF
--- a/nixd/docs/editors/nvim-lsp.nix
+++ b/nixd/docs/editors/nvim-lsp.nix
@@ -11,7 +11,7 @@ let
       '';
 
       packages.myPlugins.start = with pkgs.vimPlugins; [
-        (nvim-treesitter.withPlugins (parsers: [ parsers.nix parsers.markdown ]))
+        (nvim-treesitter.withPlugins (parsers: [ parsers.nix parsers.markdown parsers.markdown_inline ]))
         friendly-snippets
         luasnip
         nvim-cmp

--- a/nixd/docs/editors/nvim-lsp.nix
+++ b/nixd/docs/editors/nvim-lsp.nix
@@ -11,7 +11,9 @@ let
       '';
 
       packages.myPlugins.start = with pkgs.vimPlugins; [
-        (nvim-treesitter.withPlugins (parsers: [ parsers.nix parsers.markdown parsers.markdown_inline ]))
+        (nvim-treesitter.withPlugins (
+          parsers: builtins.attrValues { inherit (parsers) nix markdown markdown_inline; }
+        ))
         friendly-snippets
         luasnip
         nvim-cmp

--- a/nixd/docs/editors/nvim-lsp.nix
+++ b/nixd/docs/editors/nvim-lsp.nix
@@ -11,7 +11,7 @@ let
       '';
 
       packages.myPlugins.start = with pkgs.vimPlugins; [
-        (nvim-treesitter.withPlugins (parsers: [ parsers.nix ]))
+        (nvim-treesitter.withPlugins (parsers: [ parsers.nix parsers.markdown ]))
         friendly-snippets
         luasnip
         nvim-cmp


### PR DESCRIPTION
Add markdown to enable nixdocs shown in hover.
Closes #592