### PR TITLE
nixd/lib/Controller: disable semantic tokens feature during init

### DIFF
--- a/nixd/docs/features.md
+++ b/nixd/docs/features.md
@@ -32,13 +32,16 @@ Screenshots:
 
 ### Semantic Tokens
 
+> [!WARNING]
+> This feature is experimental and not enabled by default.
+
 [nixd language server](https://github.com/nix-community/nixd) tries to make some tokens looks different by sending your editor some integers.
 However, types in nix language is pretty different from standard LSP types.
 So, as a result, attrnames, selection, variables are colored as different integers,
 but the colors may, or may not rendered properly in your editor.
 
 > [!TIP]
-> `--semantic-tokens=false` to disable the feature.
+> `--semantic-tokens=true` to enable the feature.
 
 #### Attribute name coloring
 

--- a/nixd/lib/Controller/LifeTime.cpp
+++ b/nixd/lib/Controller/LifeTime.cpp
@@ -38,7 +38,7 @@ opt<std::string> DefaultNixOSOptionsExpr{
 
 opt<bool> EnableSemanticTokens{"semantic-tokens",
                                desc("Enable/Disable semantic tokens"),
-                               init(true), cat(NixdCategory)};
+                               init(false), cat(NixdCategory)};
 
 // Here we try to wrap nixpkgs, nixos options in a single emtpy attrset in test.
 std::string getDefaultNixpkgsExpr() {

--- a/nixd/tools/nixd/test/semantic-tokens/initialize.md
+++ b/nixd/tools/nixd/test/semantic-tokens/initialize.md
@@ -1,4 +1,4 @@
-# RUN: nixd --lit-test < %s | FileCheck %s
+# RUN: nixd --lit-test --semantic-tokens=true < %s | FileCheck %s
 
 Check basic handshake with the server, i.e. "initialize"
 
@@ -48,6 +48,32 @@ CHECK-NEXT:       "inlayHintProvider": true,
 CHECK-NEXT:       "referencesProvider": true,
 CHECK-NEXT:       "renameProvider": {
 CHECK-NEXT:         "prepareProvider": true
+CHECK-NEXT:       },
+CHECK-NEXT:       "semanticTokensProvider": {
+CHECK-NEXT:         "full": true,
+CHECK-NEXT:         "legend": {
+CHECK-NEXT:           "tokenModifiers": [
+CHECK-NEXT:             "static",
+CHECK-NEXT:             "abstract",
+CHECK-NEXT:             "async"
+CHECK-NEXT:           ],
+CHECK-NEXT:           "tokenTypes": [
+CHECK-NEXT:             "function",
+CHECK-NEXT:             "string",
+CHECK-NEXT:             "number",
+CHECK-NEXT:             "type",
+CHECK-NEXT:             "keyword",
+CHECK-NEXT:             "variable",
+CHECK-NEXT:             "interface",
+CHECK-NEXT:             "variable",
+CHECK-NEXT:             "regexp",
+CHECK-NEXT:             "macro",
+CHECK-NEXT:             "method",
+CHECK-NEXT:             "regexp",
+CHECK-NEXT:             "regexp"
+CHECK-NEXT:           ]
+CHECK-NEXT:         },
+CHECK-NEXT:         "range": false
 CHECK-NEXT:       },
 CHECK-NEXT:       "textDocumentSync": {
 CHECK-NEXT:         "change": 2,


### PR DESCRIPTION
Semantic tokens (current implementation) caused a lot of trouble for users.
The common reason is confusing attribute path coloring for "same" tokens.
i.e.

```nix
{
    program.a = 1;
    program.b = 2;
}
```

Those two "program"s are colored differently, (looks like a bug frankly).
So let's disable it for now, for UX improvement.
We can re-enable it later if we have a better implementation.

Link: https://github.com/nix-community/nixd/issues/573