### PR TITLE
Value doc

### DIFF
--- a/libnixt/include/nixt/Value.h
+++ b/libnixt/include/nixt/Value.h
@@ -70,4 +70,10 @@ selectStringViews(nix::EvalState &State, nix::Value &V,
   return selectSymbols(State, V, toSymbols(State.symbols, AttrPath));
 }
 
+/// TODO: use https://github.com/NixOS/nix/pull/11914 on nix version bump
+/// \brief Get nix's `builtins` constant
+inline nix::Value &getBuiltins(const nix::EvalState &State) {
+  return *State.baseEnv.values[0];
+}
+
 } // namespace nixt

--- a/nixd/include/nixd/Protocol/AttrSet.h
+++ b/nixd/include/nixd/Protocol/AttrSet.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>
@@ -31,6 +32,7 @@ constexpr inline std::string_view AttrPathInfo = "attrset/attrpathInfo";
 constexpr inline std::string_view AttrPathComplete = "attrset/attrpathComplete";
 constexpr inline std::string_view OptionInfo = "attrset/optionInfo";
 constexpr inline std::string_view OptionComplete = "attrset/optionComplete";
+
 constexpr inline std::string_view Exit = "exit";
 
 } // namespace rpcMethod
@@ -78,12 +80,24 @@ llvm::json::Value toJSON(const ValueMeta &Params);
 bool fromJSON(const llvm::json::Value &Params, ValueMeta &R,
               llvm::json::Path P);
 
+/// \brief Using nix's ":doc" method to retrive value's additional information.
+struct ValueDescription {
+  std::string Doc;
+  std::int64_t Arity;
+};
+
+llvm::json::Value toJSON(const ValueDescription &Params);
+bool fromJSON(const llvm::json::Value &Params, ValueDescription &R,
+              llvm::json::Path P);
+
 struct AttrPathInfoResponse {
   /// \brief General value description
   ValueMeta Meta;
 
   /// \brief Package description of the attribute path, if available.
   PackageDescription PackageDesc;
+
+  std::optional<ValueDescription> ValueDesc;
 };
 
 llvm::json::Value toJSON(const AttrPathInfoResponse &Params);

--- a/nixd/lib/Controller/Hover.cpp
+++ b/nixd/lib/Controller/Hover.cpp
@@ -56,7 +56,7 @@ class NixpkgsHoverProvider {
   ///
   /// FIXME: there are many markdown generation in language server.
   /// Maybe we can add structured generating first?
-  static std::string mkMarkdown(const PackageDescription &Package) {
+  static std::string mkPackageMarkdown(const PackageDescription &Package) {
     std::ostringstream OS;
     // Make each field a new section
 
@@ -87,6 +87,10 @@ class NixpkgsHoverProvider {
     return OS.str();
   }
 
+  static std::string mkValueMarkdown(const ValueDescription &ValueDesc) {
+    return ValueDesc.Doc;
+  }
+
 public:
   NixpkgsHoverProvider(AttrSetClient &NixpkgsClient)
       : NixpkgsClient(NixpkgsClient) {}
@@ -107,7 +111,11 @@ public:
     if (!Desc)
       return std::nullopt;
 
-    return mkMarkdown(Desc->PackageDesc);
+    if (const auto ValueDesc = Desc->ValueDesc) {
+      return ValueDesc->Doc;
+    }
+
+    return mkPackageMarkdown(Desc->PackageDesc);
   }
 };
 

--- a/nixd/lib/Eval/AttrSetProvider.cpp
+++ b/nixd/lib/Eval/AttrSetProvider.cpp
@@ -5,6 +5,7 @@
 
 #include <nix/attr-path.hh>
 #include <nix/common-eval-args.hh>
+#include <nix/eval.hh>
 #include <nix/nixexpr.hh>
 #include <nix/store-api.hh>
 #include <nixt/Value.h>
@@ -156,6 +157,43 @@ void fillOptionDescription(nix::EvalState &State, nix::Value &V,
   }
 }
 
+std::vector<std::string> completeNames(nix::Value &Scope,
+                                       const nix::EvalState &State,
+                                       std::string_view Prefix) {
+  int Num = 0;
+  std::vector<std::string> Names;
+
+  // FIXME: we may want to use "Trie" to speedup the string searching.
+  // However as my (roughtly) profiling the critical in this loop is
+  // evaluating package details.
+  // "Trie"s may not beneficial because it cannot speedup eval.
+  for (const auto *AttrPtr : Scope.attrs()->lexicographicOrder(State.symbols)) {
+    const nix::Attr &Attr = *AttrPtr;
+    const std::string_view Name = State.symbols[Attr.name];
+    if (Name.starts_with(Prefix)) {
+      ++Num;
+      Names.emplace_back(Name);
+      // We set this a very limited number as to speedup
+      if (Num > MaxItems)
+        break;
+    }
+  }
+  return Names;
+}
+
+std::optional<ValueDescription> describeValue(nix::EvalState &State,
+                                              nix::Value &V) {
+  const auto Doc = State.getDoc(V);
+  if (!Doc) {
+    return std::nullopt;
+  } else {
+    return ValueDescription{
+        .Doc = Doc->doc,
+        .Arity = static_cast<int64_t>(Doc->arity),
+    };
+  }
+}
+
 } // namespace
 
 AttrSetProvider::AttrSetProvider(std::unique_ptr<InboundPort> In,
@@ -202,9 +240,11 @@ void AttrSetProvider::onAttrPathInfo(
 
       nix::Value &V = nixt::selectStrings(state(), Nixpkgs, AttrPath);
       state().forceValue(V, nix::noPos);
+
       return RespT{
           .Meta = metadataOf(state(), V),
           .PackageDesc = describePackage(state(), V),
+          .ValueDesc = describeValue(state(), V),
       };
     } catch (const nix::BaseError &Err) {
       return error(Err.info().msg.str());
@@ -227,33 +267,11 @@ void AttrSetProvider::onAttrPathComplete(
       return;
     }
 
-    std::vector<std::string> Names;
-    int Num = 0;
-
-    // FIXME: we may want to use "Trie" to speedup the string searching.
-    // However as my (roughtly) profiling the critical in this loop is
-    // evaluating package details.
-    // "Trie"s may not beneficial becausae it cannot speedup eval.
-    for (const auto *AttrPtr :
-         Scope.attrs()->lexicographicOrder(state().symbols)) {
-      const nix::Attr &Attr = *AttrPtr;
-      const std::string_view Name = state().symbols[Attr.name];
-      if (Name.starts_with(Params.Prefix)) {
-        ++Num;
-        Names.emplace_back(Name);
-        // We set this a very limited number as to speedup
-        if (Num > MaxItems)
-          break;
-      }
-    }
-    Reply(std::move(Names));
-    return;
+    return Reply(completeNames(Scope, state(), Params.Prefix));
   } catch (const nix::BaseError &Err) {
-    Reply(error(Err.info().msg.str()));
-    return;
+    return Reply(error(Err.info().msg.str()));
   } catch (const std::exception &Err) {
-    Reply(error(Err.what()));
-    return;
+    return Reply(error(Err.what()));
   }
 }
 

--- a/nixd/lib/Protocol/AttrSet.cpp
+++ b/nixd/lib/Protocol/AttrSet.cpp
@@ -97,6 +97,7 @@ Value nixd::toJSON(const AttrPathInfoResponse &Params) {
   return Object{
       {"Meta", Params.Meta},
       {"PackageDesc", Params.PackageDesc},
+      {"ValueDesc", Params.ValueDesc},
   };
 }
 
@@ -106,6 +107,7 @@ bool nixd::fromJSON(const llvm::json::Value &Params, AttrPathInfoResponse &R,
   return O                                              //
          && O.map("Meta", R.Meta)                       //
          && O.mapOptional("PackageDesc", R.PackageDesc) //
+         && O.mapOptional("ValueDesc", R.ValueDesc)     //
       ;
 }
 
@@ -118,5 +120,21 @@ bool nixd::fromJSON(const llvm::json::Value &Params, AttrPathCompleteParams &R,
   return O                            //
          && O.map("Scope", R.Scope)   //
          && O.map("Prefix", R.Prefix) //
+      ;
+}
+
+llvm::json::Value nixd::toJSON(const ValueDescription &Params) {
+  return Object{
+      {"arity", Params.Arity},
+      {"doc", Params.Doc},
+  };
+}
+bool nixd::fromJSON(const llvm::json::Value &Params, ValueDescription &R,
+                    llvm::json::Path P) {
+
+  ObjectMapper O(Params, P);
+  return O                          //
+         && O.map("arity", R.Arity) //
+         && O.map("doc", R.Doc)     //
       ;
 }

--- a/nixd/tools/nixd-attrset-eval/test/attrs-info-doc.md
+++ b/nixd/tools/nixd-attrset-eval/test/attrs-info-doc.md
@@ -1,0 +1,50 @@
+# RUN: nixd-attrset-eval --lit-test < %s | FileCheck %s
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"attrset/evalExpr",
+   "params": "{ hello = /** some markdown docs */x: y: x; }"
+}
+```
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":1,
+   "method":"attrset/attrpathInfo",
+   "params": [ "hello" ]
+}
+```
+
+```
+     CHECK: "id": 1,
+CHECK-NEXT: "jsonrpc": "2.0",
+CHECK-NEXT: "result": {
+CHECK-NEXT:   "Meta": {
+CHECK-NEXT:     "Location": null,
+CHECK-NEXT:     "Type": 9
+CHECK-NEXT:   },
+CHECK-NEXT:   "PackageDesc": {
+CHECK-NEXT:     "Description": null,
+CHECK-NEXT:     "Homepage": null,
+CHECK-NEXT:     "LongDescription": null,
+CHECK-NEXT:     "Name": null,
+CHECK-NEXT:     "PName": null,
+CHECK-NEXT:     "Position": null,
+CHECK-NEXT:     "Version": null
+CHECK-NEXT:   },
+CHECK-NEXT:   "ValueDesc": {
+CHECK-NEXT:     "arity": 0,
+CHECK-NEXT:     "doc": "Function `hello`\\\n  … defined at «string»:1:36\n\nsome markdown docs \n"
+CHECK-NEXT:   }
+CHECK-NEXT: }
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```
+


### PR DESCRIPTION
This PR introduces `nix-repl`'s `:doc` command to nixd.

Since https://github.com/NixOS/nix/pull/11072, we can utilize the API exposed by `nix::EvalState::getDoc`. (i.e. to provide hover/completions(todo) from nixpkgs's doc comments).

Current status:

- [x] support hovering
- [ ] support completion-list resolve

| | |
|:-:|:-:|
|The `:doc` command in `nix-repl`| Hovering on that value|
|<img width="1604" src="https://github.com/user-attachments/assets/99b09522-a91e-41a9-be04-400e219ec034">|<img width="1604" src="https://github.com/user-attachments/assets/ec6668b9-b902-476b-a7c3-8e6860e646e9">|