### PR TITLE
nixd/lspserver: fix high cpu on fd polling

### DIFF
--- a/nixd/lspserver/src/Connection.cpp
+++ b/nixd/lspserver/src/Connection.cpp
@@ -157,6 +157,12 @@ bool readLine(int fd, const std::atomic<bool> &Close,
     if (Close)
       return false;
 
+    // POLLHUB: hang up from the writer side
+    // POLLNVAL: invalid request (fd not open)
+    if (FDs[0].revents & (POLLHUP | POLLNVAL)) {
+      return false;
+    }
+
     if (FDs[0].revents & POLLIN) {
       ssize_t BytesRead = read(fd, &Ch, 1);
       if (BytesRead == -1) {


### PR DESCRIPTION
Fixes #627