### PR TITLE
nixf: declare Tokens.h dependency for libnixf

### DIFF
--- a/libnixf/src/meson.build
+++ b/libnixf/src/meson.build
@@ -69,7 +69,7 @@ pkgconfig.generate(
 )
 
 nixf = declare_dependency(
-    sources: [diagnostic_enum_h],
+    sources: [diagnostic_enum_h, tokens_h],
     include_directories: libnixf_inc,
     link_with: libnixf,
     dependencies: libnixf_deps


### PR DESCRIPTION
Without the change the build sometimes fails as:

```
   @nix { "action": "setPhase", "phase": "buildPhase" }
    build flags: -j16
    [1/37] Generating src/DiagnosticEnum.h with a custom command
    [2/37] Generating src/Diagnostic.cpp with a custom command
    [3/37] Compiling C++ object test/unit-libnixf-parse.p/Parse_ParseAttrs.cpp.o
    FAILED: test/unit-libnixf-parse.p/Parse_ParseAttrs.cpp.o
    g++ -Itest/unit-libnixf-parse.p -Itest -I../test -I../src/Parse -I../include -Isrc -I/nix/store/lb7qkwdmj8wms2df787npi93ackz5lll-boost-1.87.0-dev/include -I/nix/store/bfgjwkcb8snkizx578rzdahi75m8zyh4-nlohmann_json-3.11.3/include -I/nix/store/212jw2z087s4wy7jpivr47qk9h5wrbmv-gtest-1.16.0-dev/include -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu++20 -O3 -DGTEST_HAS_PTHREAD=1 -DBOOST_ALL_NO_LIB -MD -MQ test/unit-libnixf-parse.p/Parse_ParseAttrs.cpp.o -MF test/unit-libnixf-parse.p/Parse_ParseAttrs.cpp.o.d -o test/unit-libnixf-parse.p/Parse_ParseAttrs.cpp.o -c ../test/Parse/ParseAttrs.cpp
    In file included from ../src/Parse/Lexer.h:10,
                     from ../src/Parse/Parser.h:5,
                     from ../test/Parse/ParseAttrs.cpp:3:
    ../src/Parse/Token.h:3:10: fatal error: Tokens.h: No such file or directory
        3 | #include "Tokens.h"
          |          ^~~~~~~~~~
    compilation terminated.
```

`ninja·-t·missingdeps` it's a missing dependency:

```
    $ ninja -t missingdeps

    Missing dep: test/unit-libnixf-parse.p/Parse_Lexer.cpp.o uses src/Tokens.h (generated by CUSTOM_COMMAND)
    Missing dep: test/unit-libnixf-parse.p/Parse_ParseAttrs.cpp.o uses src/Tokens.h (generated by CUSTOM_COMMAND)
    Missing dep: test/unit-libnixf-parse.p/Parse_ParseExpr.cpp.o uses src/Tokens.h (generated by CUSTOM_COMMAND)
    Missing dep: test/unit-libnixf-parse.p/Parse_ParseLambda.cpp.o uses src/Tokens.h (generated by CUSTOM_COMMAND)
    Missing dep: test/unit-libnixf-parse.p/Parse_ParseOp.cpp.o uses src/Tokens.h (generated by CUSTOM_COMMAND)
    Missing dep: test/unit-libnixf-parse.p/Parse_ParseSimple.cpp.o uses src/Tokens.h (generated by CUSTOM_COMMAND)
    Processed 38 nodes.
    Error: There are 6 missing dependency paths.
    6 targets had depfile dependencies on 1 distinct generated inputs (from 1 rules)  without a non-depfile dep path to the generator.
    There might be build flakiness if any of the targets listed above are built alone, or not late enough, in a clean output directory.
```