### PR TITLE
Fix vscodium shell to work like nvim shell.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 
 result
 result-*
+.cache

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,43 @@
             hardeningDisable = [ "fortify" ];
           };
           treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
+          mkDevShell = {cmd, editor}: pkgs.mkShell {
+            nativeBuildInputs = [
+              nixd
+              pkgs.nixfmt-rfc-style
+              pkgs.git
+              editor
+            ];
+            inputsFrom = [ config.flake-root.devShell ];
+            shellHook = ''
+              echo -e "\n\033[1;31mDuring the first time nixd launches, the flake inputs will be fetched from the internet, this is rather slow.\033[0m"
+              echo -e "\033[1;34mEntering the test environment...\033[0m"
+              cd $FLAKE_ROOT
+              export GIT_REPO=https://github.com/nix-community/nixd.git
+              export EXAMPLES_PATH=nixd/docs/examples
+              export WORK_TEMP=/tmp/NixOS_Home-Manager
+              if [ -d "$WORK_TEMP" ]; then
+                rm -rf $WORK_TEMP
+              fi
+              mkdir -p $WORK_TEMP
+              cp -r $EXAMPLES_PATH/NixOS_Home-Manager/* $WORK_TEMP/ 2>/dev/null
+              if [[ $? -ne 0 ]]; then
+                export GIT_DIR=$WORK_TEMP/.git
+                export GIT_WORK_TREE=/tmp/NixOS_Home-Manager
+                git init
+                git config core.sparseCheckout true
+                git remote add origin $GIT_REPO
+                echo "$EXAMPLES_PATH/NixOS_Home-Manager/" >$GIT_DIR/info/sparse-checkout
+                git pull origin main
+                cp $GIT_WORK_TREE\/$EXAMPLES_PATH/NixOS_Home-Manager/* $GIT_WORK_TREE 2>/dev/null
+                rm -rf $GIT_WORK_TREE/nixd
+              fi
+              cd $WORK_TEMP
+              echo -e "\033[1;32mNow, you can edit the nix file by running the following command:\033[0m"
+              echo -e "\033[1;33m'${cmd} flake.nix'\033[0m"
+              echo -e "\033[1;34mEnvironment setup complete.\033[0m"
+            '';
+          };
         in
         {
           packages.default = nixd;
@@ -72,49 +109,13 @@
 
           devShells.default = nixdMono.overrideAttrs shellOverride;
 
-          devShells.nvim = pkgs.mkShell {
-            nativeBuildInputs = [
-              nixd
-              pkgs.nixfmt-rfc-style
-              pkgs.git
-              (import ./nixd/docs/editors/nvim-lsp.nix { inherit pkgs; })
-            ];
-            inputsFrom = [ config.flake-root.devShell ];
-            shellHook = ''
-              echo -e "\n\033[1;31mDuring the first time nixd launches, the flake inputs will be fetched from the internet, this is rather slow.\033[0m"
-              echo -e "\033[1;34mEntering the nvim test environment...\033[0m"
-              cd $FLAKE_ROOT
-              export GIT_REPO=https://github.com/nix-community/nixd.git
-              export EXAMPLES_PATH=nixd/docs/examples
-              export WORK_TEMP=/tmp/NixOS_Home-Manager
-              if [ -d "$WORK_TEMP" ]; then
-              	rm -rf $WORK_TEMP
-              fi
-              mkdir -p $WORK_TEMP
-              cp -r $EXAMPLES_PATH/NixOS_Home-Manager/* $WORK_TEMP/ 2>/dev/null
-              if [[ $? -ne 0 ]]; then
-              	export GIT_DIR=$WORK_TEMP/.git
-              	export GIT_WORK_TREE=/tmp/NixOS_Home-Manager
-              	git init
-              	git config core.sparseCheckout true
-              	git remote add origin $GIT_REPO
-              	echo "$EXAMPLES_PATH/NixOS_Home-Manager/" >$GIT_DIR/info/sparse-checkout
-              	git pull origin main
-              	cp $GIT_WORK_TREE\/$EXAMPLES_PATH/NixOS_Home-Manager/* $GIT_WORK_TREE 2>/dev/null
-              	rm -rf $GIT_WORK_TREE/nixd
-              fi
-              cd $WORK_TEMP
-              echo -e "\033[1;32mNow, you can edit the nix file by running the following command:\033[0m"
-              echo -e "\033[1;33m'nvim-lsp flake.nix'\033[0m"
-              echo -e "\033[1;34mEnvironment setup complete.\033[0m"
-            '';
+          devShells.nvim = mkDevShell {
+            cmd = "nvim-lsp";
+            editor = import ./nixd/docs/editors/nvim-lsp.nix { inherit pkgs; };
           };
-          devShells.vscodium = pkgs.mkShell {
-            nativeBuildInputs = [
-              nixd
-              pkgs.nixfmt-rfc-style
-              (import ./nixd/docs/editors/vscodium.nix { inherit pkgs; })
-            ];
+          devShells.vscodium = mkDevShell {
+            cmd = "codium-test";
+            editor = import ./nixd/docs/editors/vscodium.nix { inherit pkgs; };
           };
           formatter = treefmtEval.config.build.wrapper;
         };

--- a/nixd/docs/editors/vscode-settings.json
+++ b/nixd/docs/editors/vscode-settings.json
@@ -1,0 +1,28 @@
+{
+  "security.workspace.trust.enabled": false,
+  "nix.enableLanguageServer": true,
+  "nix.serverPath": "nixd",
+  "nix.serverSettings": {
+    "nixd": {
+      "nixpkgs": {
+        "expr": "import <nixpkgs> { }"
+      },
+      "formatting": {
+        "command": [
+          "nixfmt"
+        ]
+      },
+      "options": {
+        "nixos": {
+          "expr": "(builtins.getFlake \"/tmp/NixOS_Home-Manager\").nixosConfigurations.hostname.options"
+        },
+        "home-manager": {
+          "expr": "(builtins.getFlake \"/tmp/NixOS_Home-Manager\").homeConfigurations.\"user@hostname\".options"
+        },
+        "flake-parts": {
+          "expr": "let flake = builtins.getFlake (\"/tmp/NixOS_Home-Manager\"); in flake.debug.options // flake.currentSystem.options"
+        }
+      }
+    }
+  }
+}

--- a/nixd/docs/editors/vscodium.nix
+++ b/nixd/docs/editors/vscodium.nix
@@ -14,12 +14,6 @@ writeShellScriptBin "codium-test" ''
   set -e
   dir="''${XDG_CACHE_HOME:-~/.cache}/nixd-codium"
   ${coreutils}/bin/mkdir -p "$dir/User"
-  cat >"$dir/User/settings.json" <<EOF
-  {
-  "security.workspace.trust.enabled": false,
-  "nix.enableLanguageServer": true,
-  "nix.serverPath": "nixd",
-  }
-  EOF
+  cp ${./vscode-settings.json} "$dir/User/settings.json"
   ${codium}/bin/codium --user-data-dir "$dir" "$@"
 ''


### PR DESCRIPTION
Unlike the nvim shell, the vscodium shell didn't specify any nixd server settings, so the example `flake.nix` didn't work. Fixed this by:

- Pulling vscodium's user settings.json into a separate file, and filling it with the same contents as the config elaborated in nvim-lsp.nix.

- Moved dev shell generation in the nixd repo's `flake.nix` to a common `mkDevShell` function for both nvim and vscodium (since the `settings.json` is sepecific to the hardcoded `/tmp/NixOS_Home-Manager` path.)

Ideally we'd read the nixd server settings from the same file for both nvim and vscodium, but I don't know Lua so I didn't want to touch it.