### PR TITLE
nixd: enable completion and hover in config sets

### DIFF
--- a/nixd/lib/Controller/AST.cpp
+++ b/nixd/lib/Controller/AST.cpp
@@ -315,3 +315,19 @@ nixd::FindAttrPathResult nixd::findAttrPath(const nixf::Node &N,
 
   return R::NotAttrPath;
 }
+
+nixd::FindAttrPathResult
+nixd::findAttrPathForOptions(const nixf::Node &N,
+                             const nixf::ParentMapAnalysis &PM,
+                             std::vector<std::string> &Path) {
+
+  const auto R = findAttrPath(N, PM, Path);
+  if (R == FindAttrPathResult::OK) {
+    // FIXME: Only do this in NixOS module files and in flakes only in module
+    // functions passed to nixpkgs.lib.nixosSystem.
+    if (!Path.empty() && Path[0] == "config") {
+      Path.erase(Path.begin());
+    }
+  }
+  return R;
+}

--- a/nixd/lib/Controller/AST.h
+++ b/nixd/lib/Controller/AST.h
@@ -129,4 +129,12 @@ FindAttrPathResult findAttrPath(const nixf::Node &N,
                                 const nixf::ParentMapAnalysis &PM,
                                 std::vector<std::string> &Path);
 
+/// \brief Heuristically find attrpath suitable for "attrpath" completion.
+/// Strips "config." from the start to support config sections in NixOS modules.
+///
+/// \param[out] Path the attrpath.
+FindAttrPathResult findAttrPathForOptions(const nixf::Node &N,
+                                          const nixf::ParentMapAnalysis &PM,
+                                          std::vector<std::string> &Path);
+
 } // namespace nixd

--- a/nixd/lib/Controller/Completion.cpp
+++ b/nixd/lib/Controller/Completion.cpp
@@ -275,7 +275,7 @@ void completeAttrPath(const Node &N, const ParentMapAnalysis &PM,
                       std::vector<lspserver::CompletionItem> &Items) {
   std::vector<std::string> Scope;
   using PathResult = FindAttrPathResult;
-  auto R = findAttrPath(N, PM, Scope);
+  auto R = findAttrPathForOptions(N, PM, Scope);
   if (R == PathResult::OK) {
     // Construct request.
     std::string Prefix = Scope.back();

--- a/nixd/lib/Controller/Definition.cpp
+++ b/nixd/lib/Controller/Definition.cpp
@@ -240,7 +240,7 @@ Locations defineAttrPath(const Node &N, const ParentMapAnalysis &PM,
                          Controller::OptionMapTy &Options) {
   using PathResult = FindAttrPathResult;
   std::vector<std::string> Scope;
-  auto R = findAttrPath(N, PM, Scope);
+  auto R = findAttrPathForOptions(N, PM, Scope);
   Locations Locs;
   if (R == PathResult::OK) {
     std::lock_guard _(OptionsLock);

--- a/nixd/lib/Controller/Hover.cpp
+++ b/nixd/lib/Controller/Hover.cpp
@@ -147,7 +147,7 @@ void Controller::onHover(const TextDocumentPositionParams &Params,
       }
 
       auto Scope = std::vector<std::string>();
-      const auto R = findAttrPath(N, PM, Scope);
+      const auto R = findAttrPathForOptions(N, PM, Scope);
       if (R == FindAttrPathResult::OK) {
         std::lock_guard _(OptionsLock);
         for (const auto &[_, Client] : Options) {

--- a/nixd/tools/nixd/test/completion/options-in-config.md
+++ b/nixd/tools/nixd/test/completion/options-in-config.md
@@ -1,0 +1,81 @@
+# RUN: nixd --lit-test \
+# RUN: --nixos-options-expr="{ foo.bar = { _type = \"option\"; }; }" \
+# RUN: < %s | FileCheck %s
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "method":"textDocument/didOpen",
+   "params":{
+      "textDocument":{
+         "uri":"file:///completion.nix",
+         "languageId":"nix",
+         "version":1,
+         "text":"{ config = { fo }; }"
+      }
+   }
+}
+```
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "textDocument/completion",
+    "params": {
+        "textDocument": {
+            "uri": "file:///completion.nix"
+        },
+        "position": {
+            "line": 0,
+            "character": 15
+        },
+        "context": {
+            "triggerKind": 1
+        }
+    }
+}
+```
+
+```
+     CHECK: "id": 1,
+CHECK-NEXT:  "jsonrpc": "2.0",
+CHECK-NEXT:  "result": {
+CHECK-NEXT:    "isIncomplete": false,
+CHECK-NEXT:    "items": [
+CHECK-NEXT:      {
+CHECK-NEXT:        "data": "",
+CHECK-NEXT:        "detail": "nixos",
+CHECK-NEXT:        "kind": 7,
+CHECK-NEXT:        "label": "foo",
+CHECK-NEXT:        "score": 0
+CHECK-NEXT:      }
+CHECK-NEXT:    ]
+CHECK-NEXT:  }
+```
+
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/hover/options-in-config.md
+++ b/nixd/tools/nixd/test/hover/options-in-config.md
@@ -1,0 +1,82 @@
+# RUN: nixd --lit-test \
+# RUN: --nixos-options-expr="{ foo = { _type = \"option\"; description = \"test option\"; type.description = \"test type\"; }; }" \
+# RUN: < %s | FileCheck %s
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "method":"textDocument/didOpen",
+   "params":{
+      "textDocument":{
+         "uri":"file:///test.nix",
+         "languageId":"nix",
+         "version":1,
+         "text":"{ config = { foo }; }"
+      }
+   }
+}
+```
+
+```json
+{
+   "jsonrpc": "2.0",
+   "id": 2,
+   "method": "textDocument/hover",
+   "params":{
+      "textDocument":{
+         "uri": "file:///test.nix"
+      },
+      "position":{
+         "line": 0,
+         "character": 15
+      }
+   }
+}
+```
+
+```
+     CHECK:  "id": 2,
+CHECK-NEXT:  "jsonrpc": "2.0",
+CHECK-NEXT:  "result": {
+CHECK-NEXT:    "contents": {
+CHECK-NEXT:      "kind": "markdown",
+CHECK-NEXT:      "value": " (test type)\n\ntest option"
+CHECK-NEXT:    },
+CHECK-NEXT:    "range": {
+CHECK-NEXT:      "end": {
+CHECK-NEXT:        "character": 16,
+CHECK-NEXT:        "line": 0
+CHECK-NEXT:      },
+CHECK-NEXT:      "start": {
+CHECK-NEXT:        "character": 13,
+CHECK-NEXT:        "line": 0
+CHECK-NEXT:      }
+CHECK-NEXT:    }
+CHECK-NEXT:  }
+```
+
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```


### PR DESCRIPTION
In NixOS modules options can be defined at the top-level, e.g:

    { foo = true; }

or inside of `config`, e.g:

    { config = { foo = true; }; }

Autocompletion and hover information before only worked for the former because the option resolving code had no special handling for `config`.

Fixes #566.