### PR TITLE
nixd/test: specify textDocument/didOpen via nix code blocks

### DIFF
--- a/nixd/lspserver/include/lspserver/Connection.h
+++ b/nixd/lspserver/include/lspserver/Connection.h
@@ -40,8 +40,12 @@ public:
 
   JSONStreamStyle StreamStyle = JSONStreamStyle::Standard;
 
+  /// Read one message as specified in the LSP standard.
+  /// A Language Server Protocol message starts with a set of
+  /// HTTP headers, delimited  by \r\n, and terminated by an empty line (\r\n).
   bool readStandardMessage(std::string &JSONString);
 
+  /// Read one message, expecting the input to be one of our Markdown lit-tests.
   bool readDelimitedMessage(std::string &JSONString);
 
   /// \brief Notify the inbound port to close the connection
@@ -51,10 +55,7 @@ public:
               JSONStreamStyle StreamStyle = JSONStreamStyle::Standard)
       : Close(false), In(In), StreamStyle(StreamStyle) {};
 
-  /// Read messages specified in LSP standard, and collect standard json string
-  /// into \p JSONString.
-  /// A Language Server Protocol message starts with a set of
-  /// HTTP headers, delimited  by \r\n, and terminated by an empty line (\r\n).
+  /// Read one LSP message into \p JSONString depending on the configured StreamStyle.
   bool readMessage(std::string &JSONString);
 
   /// Dispatch messages to on{Notify,Call,Reply} ( \p Handlers)

--- a/nixd/lspserver/include/lspserver/Connection.h
+++ b/nixd/lspserver/include/lspserver/Connection.h
@@ -43,10 +43,10 @@ public:
   /// Read one message as specified in the LSP standard.
   /// A Language Server Protocol message starts with a set of
   /// HTTP headers, delimited  by \r\n, and terminated by an empty line (\r\n).
-  bool readStandardMessage(std::string &JSONString);
+  llvm::Expected<llvm::json::Value> readStandardMessage(std::string &Buffer);
 
   /// Read one message, expecting the input to be one of our Markdown lit-tests.
-  bool readDelimitedMessage(std::string &JSONString);
+  llvm::Expected<llvm::json::Value> readDelimitedMessage(std::string &Buffer);
 
   /// \brief Notify the inbound port to close the connection
   void close() { Close = true; }
@@ -55,8 +55,9 @@ public:
               JSONStreamStyle StreamStyle = JSONStreamStyle::Standard)
       : Close(false), In(In), StreamStyle(StreamStyle) {};
 
-  /// Read one LSP message into \p JSONString depending on the configured StreamStyle.
-  bool readMessage(std::string &JSONString);
+  /// Read one LSP message depending on the configured StreamStyle.
+  /// The parsed value is returned. The given \p Buffer is only used internally.
+  llvm::Expected<llvm::json::Value> readMessage(std::string &Buffer);
 
   /// Dispatch messages to on{Notify,Call,Reply} ( \p Handlers)
   /// Return values should be forwarded from \p Handlers

--- a/nixd/lspserver/src/Connection.cpp
+++ b/nixd/lspserver/src/Connection.cpp
@@ -249,7 +249,6 @@ InboundPort::readDelimitedMessage(std::string &Buffer) {
   Buffer.clear();
   llvm::SmallString<128> Line;
   std::string NixDocURI;
-  std::string NixDoc;
   while (readLine(In, Close, Line)) {
     auto LineRef = Line.str().trim();
     if (State == State::Prose) {
@@ -288,14 +287,14 @@ InboundPort::readDelimitedMessage(std::string &Buffer) {
                             {"uri", NixDocURI},
                             {"languageId", "nix"},
                             {"version", 1},
-                            {"text", llvm::StringRef(NixDoc).rtrim().str()},
+                            {"text", llvm::StringRef(Buffer).rtrim().str()},
                         },
                     },
                 },
             }};
       }
-      NixDoc += Line;
-      NixDoc += "\n";
+      Buffer += Line;
+      Buffer += "\n";
     } else {
       assert(false && "unreachable");
     }

--- a/nixd/tools/nixd/test/code-action/quick-fix.md
+++ b/nixd/tools/nixd/test/code-action/quick-fix.md
@@ -21,19 +21,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"/*"
-      }
-   }
-}
+```nix file:///basic.nix
+/*
 ```
 
 <-- textDocument/codeAction(2)

--- a/nixd/tools/nixd/test/completion/comment.md
+++ b/nixd/tools/nixd/test/completion/comment.md
@@ -23,19 +23,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ x = 1; y = /*   */2;}"
-      }
-   }
-}
+```nix file:///completion.nix
+{ x = 1; y = /*   */2;}
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/dot-select.md
+++ b/nixd/tools/nixd/test/completion/dot-select.md
@@ -23,19 +23,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ bar = 1; foo = foo.foo.; }"
-      }
-   }
-}
+```nix file:///completion.nix
+{ bar = 1; foo = foo.foo.; }
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/dot.md
+++ b/nixd/tools/nixd/test/completion/dot.md
@@ -23,19 +23,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ bar = 1; foo. }"
-      }
-   }
-}
+```nix file:///completion.nix
+{ bar = 1; foo. }
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/nested.md
+++ b/nixd/tools/nixd/test/completion/nested.md
@@ -23,19 +23,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ bar = 1; foo = { ba = }; }"
-      }
-   }
-}
+```nix file:///completion.nix
+{ bar = 1; foo = { ba = }; }
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/nixpkgs.md
+++ b/nixd/tools/nixd/test/completion/nixpkgs.md
@@ -21,19 +21,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"with pkgs; [ a ]"
-      }
-   }
-}
+```nix file:///completion.nix
+with pkgs; [ a ]
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/option-stop.md
+++ b/nixd/tools/nixd/test/completion/option-stop.md
@@ -23,19 +23,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ bar = 1; foo.bar. }"
-      }
-   }
-}
+```nix file:///completion.nix
+{ bar = 1; foo.bar. }
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/options-in-config.md
+++ b/nixd/tools/nixd/test/completion/options-in-config.md
@@ -23,19 +23,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ config = { fo }; }"
-      }
-   }
-}
+```nix file:///completion.nix
+{ config = { foo }; }
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/options-mid.md
+++ b/nixd/tools/nixd/test/completion/options-mid.md
@@ -23,19 +23,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ bar = 1; fo. bar = 1; }"
-      }
-   }
-}
+```nix file:///completion.nix
+{ bar = 1; fo. bar = 1; }
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/options-no-snippet.md
+++ b/nixd/tools/nixd/test/completion/options-no-snippet.md
@@ -23,19 +23,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ bar = 1; foo.ba }"
-      }
-   }
-}
+```nix file:///completion.nix
+{ bar = 1; foo.ba }
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/options-snippet.md
+++ b/nixd/tools/nixd/test/completion/options-snippet.md
@@ -30,19 +30,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ bar = 1; foo.ba }"
-      }
-   }
-}
+```nix file:///completion.nix
+{ bar = 1; foo.ba }
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/options.md
+++ b/nixd/tools/nixd/test/completion/options.md
@@ -23,19 +23,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ bar = 1; fo }"
-      }
-   }
-}
+```nix file:///completion.nix
+{ bar = 1; fo }
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/pkgs.md
+++ b/nixd/tools/nixd/test/completion/pkgs.md
@@ -24,19 +24,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"pkgs"
-      }
-   }
-}
+```nix file:///completion.nix
+pkgs
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/select-lib.md
+++ b/nixd/tools/nixd/test/completion/select-lib.md
@@ -24,19 +24,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"lib.hel"
-      }
-   }
-}
+```nix file:///completion.nix
+lib.hel
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/select.md
+++ b/nixd/tools/nixd/test/completion/select.md
@@ -24,19 +24,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"pkgs.hel"
-      }
-   }
-}
+```nix file:///completion.nix
+pkgs.hel
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/var.md
+++ b/nixd/tools/nixd/test/completion/var.md
@@ -21,19 +21,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"let xxx = 1; yy = 2; in x"
-      }
-   }
-}
+```nix file:///completion.nix
+let xxx = 1; yy = 2; in x
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/with-expr-select.md
+++ b/nixd/tools/nixd/test/completion/with-expr-select.md
@@ -21,19 +21,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"with pkgs.ax; [ b ]"
-      }
-   }
-}
+```nix file:///completion.nix
+with pkgs.ax; [ b ]
 ```
 
 ```json

--- a/nixd/tools/nixd/test/completion/with-select.md
+++ b/nixd/tools/nixd/test/completion/with-select.md
@@ -21,19 +21,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///completion.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"with pkgs; [ ax.b ]"
-      }
-   }
-}
+```nix file:///completion.nix
+with pkgs; [ ax.b ]
 ```
 
 ```json

--- a/nixd/tools/nixd/test/definition/builtin.md
+++ b/nixd/tools/nixd/test/definition/builtin.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"builtins"
-      }
-   }
-}
+```nix file:///basic.nix
+builtins
 ```
 
 <-- textDocument/definition(2)

--- a/nixd/tools/nixd/test/definition/inherit.md
+++ b/nixd/tools/nixd/test/definition/inherit.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"let x = 1; in { inherit x; }"
-      }
-   }
-}
+```nix file:///basic.nix
+let x = 1; in { inherit x; }
 ```
 
 <-- textDocument/definition(2)

--- a/nixd/tools/nixd/test/definition/let-in.md
+++ b/nixd/tools/nixd/test/definition/let-in.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"let x = 1; in x"
-      }
-   }
-}
+```nix file:///basic.nix
+let x = 1; in x
 ```
 
 <-- textDocument/definition(2)

--- a/nixd/tools/nixd/test/definition/options.md
+++ b/nixd/tools/nixd/test/definition/options.md
@@ -22,19 +22,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ foo = 1; }"
-      }
-   }
-}
+```nix file:///basic.nix
+{ foo = 1; }
 ```
 
 <-- textDocument/definition(2)

--- a/nixd/tools/nixd/test/definition/package.md
+++ b/nixd/tools/nixd/test/definition/package.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"with pkgs; x"
-      }
-   }
-}
+```nix file:///basic.nix
+with pkgs; x
 ```
 
 <-- textDocument/definition(2)

--- a/nixd/tools/nixd/test/definition/select-package-with.md
+++ b/nixd/tools/nixd/test/definition/select-package-with.md
@@ -23,19 +23,8 @@ i.e. testing if `with pkgs; [x.y]` works.
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"with pkgs; [x.y]"
-      }
-   }
-}
+```nix file:///basic.nix
+with pkgs; [x.y]
 ```
 
 <-- textDocument/definition(2)

--- a/nixd/tools/nixd/test/definition/select-package.md
+++ b/nixd/tools/nixd/test/definition/select-package.md
@@ -23,19 +23,8 @@ i.e. testing if `pkgs.x` works.
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"pkgs.x"
-      }
-   }
-}
+```nix file:///basic.nix
+pkgs.x
 ```
 
 <-- textDocument/definition(2)

--- a/nixd/tools/nixd/test/definition/with.md
+++ b/nixd/tools/nixd/test/definition/with.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"with pkgs; x"
-      }
-   }
-}
+```nix file:///basic.nix
+with pkgs; x
 ```
 
 <-- textDocument/definition(2)

--- a/nixd/tools/nixd/test/diagnostic/liveness-formal.md
+++ b/nixd/tools/nixd/test/diagnostic/liveness-formal.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{x, y}: x + 1"
-      }
-   }
-}
+```nix file:///basic.nix
+{x, y}: x + 1
 ```
 
 ```

--- a/nixd/tools/nixd/test/diagnostic/liveness-path.md
+++ b/nixd/tools/nixd/test/diagnostic/liveness-path.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{x, y}: ./${x}/${y}"
-      }
-   }
-}
+```nix file:///basic.nix
+{x, y}: ./${x}/${y}
 ```
 
 ```

--- a/nixd/tools/nixd/test/diagnostic/liveness.md
+++ b/nixd/tools/nixd/test/diagnostic/liveness.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"x: y: x + 1"
-      }
-   }
-}
+```nix file:///basic.nix
+x: y: x + 1
 ```
 
 ```

--- a/nixd/tools/nixd/test/document-highlight/basic.md
+++ b/nixd/tools/nixd/test/document-highlight/basic.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"let x = 1; y = 2; in x + y"
-      }
-   }
-}
+```nix file:///basic.nix
+let x = 1; y = 2; in x + y
 ```
 
 <-- textDocument/documentHighlight(2)

--- a/nixd/tools/nixd/test/document-highlight/builtin.md
+++ b/nixd/tools/nixd/test/document-highlight/builtin.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"[ fetchTree fetchTree true ]"
-      }
-   }
-}
+```nix file:///basic.nix
+[ fetchTree fetchTree true ]
 ```
 
 <-- textDocument/documentHighlight(2)

--- a/nixd/tools/nixd/test/document-highlight/fail.md
+++ b/nixd/tools/nixd/test/document-highlight/fail.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"let x = 1; y = 2; in x + y"
-      }
-   }
-}
+```nix file:///basic.nix
+let x = 1; y = 2; in x + y
 ```
 
 <-- textDocument/documentHighlight(2)

--- a/nixd/tools/nixd/test/document-symbol/basic.md
+++ b/nixd/tools/nixd/test/document-symbol/basic.md
@@ -21,7 +21,7 @@
 <-- textDocument/didOpen
 
 
-```nix
+```nix file:///basic.nix
 {
     x = 1;
     anonymousLambda = { a }: a;
@@ -33,24 +33,8 @@
     string2 = "${builtins.foo}";
     undefined = x;
     list = [ 1 2 3 ];
-    null = null;
-    wit = with builtins; [ a b c];
 }
-```
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{\n    x = 1;\n    anonymousLambda = { a }: a;\n    namedLambda = a: a;\n    numbers = 1 + 2.0;\n    bool = true;\n    bool2= false;\n    string = \"1\";\n    string2 = \"${builtins.foo}\";\n    undefined = x;\n    list = [ 1 2 3 ];\n}\n"
-      }
-   }
-}
 ```
 
 <-- textDocument/documentSymbol(2)

--- a/nixd/tools/nixd/test/document-symbol/dynamic-attr.md
+++ b/nixd/tools/nixd/test/document-symbol/dynamic-attr.md
@@ -22,19 +22,8 @@
 
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ ${builtins.foo} = bar; }"
-      }
-   }
-}
+```nix file:///basic.nix
+{ ${builtins.foo} = bar; }
 ```
 
 <-- textDocument/documentSymbol(2)

--- a/nixd/tools/nixd/test/format/format.md
+++ b/nixd/tools/nixd/test/format/format.md
@@ -17,19 +17,10 @@
 }
 ```
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///format.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ stdenv,\npkgs}: \n let x=1; in { y = x; }"
-      }
-   }
-}
+```nix file:///format.nix
+{ stdenv,
+pkgs}: 
+ let x=1; in { y = x; }
 ```
 
 <-- textDocument/formatting

--- a/nixd/tools/nixd/test/hover/1.md
+++ b/nixd/tools/nixd/test/hover/1.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ a = 1; }"
-      }
-   }
-}
+```nix file:///basic.nix
+{ a = 1; }
 ```
 
 <-- textDocument/hover(1)

--- a/nixd/tools/nixd/test/hover/2.md
+++ b/nixd/tools/nixd/test/hover/2.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ a = 1; }"
-      }
-   }
-}
+```nix file:///basic.nix
+{ a = 1; }
 ```
 
 <-- textDocument/hover(2)

--- a/nixd/tools/nixd/test/hover/options-in-config.md
+++ b/nixd/tools/nixd/test/hover/options-in-config.md
@@ -23,19 +23,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///test.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ config = { foo }; }"
-      }
-   }
-}
+```nix file:///test.nix
+{ config = { foo }; }
 ```
 
 ```json

--- a/nixd/tools/nixd/test/hover/options.md
+++ b/nixd/tools/nixd/test/hover/options.md
@@ -23,19 +23,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ foo.bar = 1 }"
-      }
-   }
-}
+```nix file:///basic.nix
+{ foo.bar = 1 }
 ```
 
 <-- textDocument/hover(2)

--- a/nixd/tools/nixd/test/hover/package.md
+++ b/nixd/tools/nixd/test/hover/package.md
@@ -23,19 +23,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"with pkgs;  hello"
-      }
-   }
-}
+```nix file:///basic.nix
+with pkgs;  hello
 ```
 
 <-- textDocument/hover(2)

--- a/nixd/tools/nixd/test/inlay-hint.md
+++ b/nixd/tools/nixd/test/inlay-hint.md
@@ -19,19 +19,8 @@
 }
 ```
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"with pkgs; [ hello  ]"
-      }
-   }
-}
+```nix file:///basic.nix
+with pkgs; [ hello  ]
 ```
 
 

--- a/nixd/tools/nixd/test/references/comment.md
+++ b/nixd/tools/nixd/test/references/comment.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"/*"
-      }
-   }
-}
+```nix file:///basic.nix
+/*
 ```
 
 ```

--- a/nixd/tools/nixd/test/references/lambda.md
+++ b/nixd/tools/nixd/test/references/lambda.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"arg @ { foo, bar }: arg + foo + bar + arg"
-      }
-   }
-}
+```nix file:///basic.nix
+arg @ { foo, bar }: arg + foo + bar + arg
 ```
 
 <-- textDocument/references(2)

--- a/nixd/tools/nixd/test/references/let.md
+++ b/nixd/tools/nixd/test/references/let.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"let x = 1; y = 2; in x + y"
-      }
-   }
-}
+```nix file:///basic.nix
+let x = 1; y = 2; in x + y
 ```
 
 <-- textDocument/references(2)

--- a/nixd/tools/nixd/test/references/rec.md
+++ b/nixd/tools/nixd/test/references/rec.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"rec { x = 1; y = x; }"
-      }
-   }
-}
+```nix file:///basic.nix
+rec { x = 1; y = x; }
 ```
 
 <-- textDocument/references(2)

--- a/nixd/tools/nixd/test/references/var.md
+++ b/nixd/tools/nixd/test/references/var.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"arg @ { foo, bar }: arg + foo + bar + arg"
-      }
-   }
-}
+```nix file:///basic.nix
+arg @ { foo, bar }: arg + foo + bar + arg
 ```
 
 <-- textDocument/references(2)

--- a/nixd/tools/nixd/test/references/with.md
+++ b/nixd/tools/nixd/test/references/with.md
@@ -20,19 +20,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"with builtins; foo + bar"
-      }
-   }
-}
+```nix file:///basic.nix
+with builtins; foo + bar
 ```
 
 <-- textDocument/references(2)

--- a/nixd/tools/nixd/test/rename/builtin.md
+++ b/nixd/tools/nixd/test/rename/builtin.md
@@ -21,19 +21,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"with builtins; aa"
-      }
-   }
-}
+```nix file:///basic.nix
+with builtins; aa
 ```
 
 <-- textDocument/rename(2)

--- a/nixd/tools/nixd/test/rename/duplicated.md
+++ b/nixd/tools/nixd/test/rename/duplicated.md
@@ -22,19 +22,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"rec { bar = 1; a = 1; a = bar; b = a; }"
-      }
-   }
-}
+```nix file:///basic.nix
+rec { bar = 1; a = 1; a = bar; b = a; }
 ```
 
 <-- textDocument/rename(2)

--- a/nixd/tools/nixd/test/rename/issue-255-1.md
+++ b/nixd/tools/nixd/test/rename/issue-255-1.md
@@ -22,19 +22,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{a ? 1}: { x = a; }"
-      }
-   }
-}
+```nix file:///basic.nix
+{a ? 1}: { x = a; }
 ```
 
 <-- textDocument/rename(2)

--- a/nixd/tools/nixd/test/rename/issue-255-2.md
+++ b/nixd/tools/nixd/test/rename/issue-255-2.md
@@ -22,19 +22,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{a ? 1}: { x = a; }"
-      }
-   }
-}
+```nix file:///basic.nix
+{a ? 1}: { x = a; }
 ```
 
 <-- textDocument/rename(2)

--- a/nixd/tools/nixd/test/rename/with.md
+++ b/nixd/tools/nixd/test/rename/with.md
@@ -21,19 +21,8 @@
 
 <-- textDocument/didOpen
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"with builtins; aa"
-      }
-   }
-}
+```nix file:///basic.nix
+with builtins; aa
 ```
 
 <-- textDocument/rename(2)

--- a/nixd/tools/nixd/test/semantic-tokens/basic.md
+++ b/nixd/tools/nixd/test/semantic-tokens/basic.md
@@ -20,8 +20,7 @@
 
 <-- textDocument/didOpen
 
-
-```nix
+```nix file:///basic.nix
 {
     x = 1;
     anonymousLambda = { a }: a;
@@ -33,24 +32,8 @@
     string2 = "${builtins.foo}";
     undefined = x;
     list = [ 1 2 3 ];
-    null = null;
-    wit = with builtins; [ a b c];
 }
-```
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{\n    x = 1;\n    anonymousLambda = { a }: a;\n    namedLambda = a: a;\n    numbers = 1 + 2.0;\n    bool = true;\n    bool2= false;\n    string = \"1\";\n    string2 = \"${builtins.foo}\";\n    undefined = x;\n    list = [ 1 2 3 ];\n}\n"
-      }
-   }
-}
 ```
 
 <-- textDocument/semanticTokens(2)

--- a/nixd/tools/nixd/test/semantic-tokens/inherit.md
+++ b/nixd/tools/nixd/test/semantic-tokens/inherit.md
@@ -21,19 +21,8 @@
 <-- textDocument/didOpen
 
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ inherit (builtins) concatLists listToAttrs filter attrNames; }"
-      }
-   }
-}
+```nix file:///basic.nix
+{ inherit (builtins) concatLists listToAttrs filter attrNames; }
 ```
 
 <-- textDocument/semanticTokens(2)

--- a/nixd/tools/nixd/test/utf16.md
+++ b/nixd/tools/nixd/test/utf16.md
@@ -17,19 +17,8 @@
 }
 ```
 
-```json
-{
-   "jsonrpc":"2.0",
-   "method":"textDocument/didOpen",
-   "params":{
-      "textDocument":{
-         "uri":"file:///basic.nix",
-         "languageId":"nix",
-         "version":1,
-         "text":"{ a = 1; 测试文本 }"
-      }
-   }
-}
+```nix file:///basic.nix
+{ a = 1; 测试文本 }
 ```
 
 ```


### PR DESCRIPTION
This makes the test cases less verbose and enables syntax highlighting but most importantly makes multiline documents readable so that test definitions don't contain lines such as:

    "text":"{\n    x = 1;\n    anonymousLambda = { a }: a;\n    namedLambda = a: a;\n    numbers = 1 + 2.0;\n    bool = true;\n    bool2= false;\n    string = \"1\";\n    string2 = \"${builtins.foo}\";\n    undefined = x;\n    list = [ 1 2 3 ];\n}\n"

Before multiline documents were duplicated in another nix code block (that was ignored by the test runner) for readability but these duplicated code blocks could (and did) of course get out of sync with the actual test code.