### PR TITLE
docs/editor-setup.md: add kate editor

### DIFF
--- a/nixd/docs/editor-setup.md
+++ b/nixd/docs/editor-setup.md
@@ -125,6 +125,21 @@ language-servers = ["nixd","nil"]
 command = "nixd"
 ```
 
+### KDE Kate
+Kate with [LSP Client Plugin:](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html)
+#### /$HOME/$USER/.config/kate/lspclient/settings.json
+
+```jsonc
+{
+  "servers": {
+    "nix": {
+      "command": ["nixd"],
+      "url": "https://github.com/nix-community/nixd",
+      "highlightingModeRegex": "^Nix$"
+    }
+  }
+}
+```
 ## Change the configuration.
 
 Read the [configuration](configuration.md) docs here.


### PR DESCRIPTION
Added simple example to setup KDE Kate editor, using the supported  LSP Client Plugin. Also added a link to the LSP Client Plugin documentation site for KDE and an example for the settings file path.