### PR TITLE
prefer `nix profile add` over `nix profile install`

### DIFF
--- a/nixd/docs/editor-setup.md
+++ b/nixd/docs/editor-setup.md
@@ -43,7 +43,7 @@ nix-env -iA nixpkgs.nixd
 <summary><b>nix profile</b></summary>
 
 ```console
-nix profile install github:nixos/nixpkgs#nixd
+nix profile add github:nixos/nixpkgs#nixd
 ```
 
 </details>


### PR DESCRIPTION
just setting up for the first time and `nix` warns me:
```
warning: 'install' is a deprecated alias for 'add'
```

maybe best to use `add` in the docs