### PR TITLE
nixd/Controller: clear diagnostics when removing document

### DIFF
--- a/nixd/lib/Controller/Support.cpp
+++ b/nixd/lib/Controller/Support.cpp
@@ -17,6 +17,8 @@ void Controller::removeDocument(lspserver::PathRef File) {
     std::lock_guard _(TUsLock);
     TUs.erase(File);
   }
+  std::vector<nixf::Diagnostic> Diagnostics;
+  publishDiagnostics(File, std::nullopt, "", Diagnostics);
 }
 
 void Controller::actOnDocumentAdd(PathRef File,

--- a/nixd/lib/Controller/Support.cpp
+++ b/nixd/lib/Controller/Support.cpp
@@ -17,8 +17,7 @@ void Controller::removeDocument(lspserver::PathRef File) {
     std::lock_guard _(TUsLock);
     TUs.erase(File);
   }
-  std::vector<nixf::Diagnostic> Diagnostics;
-  publishDiagnostics(File, std::nullopt, "", Diagnostics);
+  publishDiagnostics(File, std::nullopt, "", {});
 }
 
 void Controller::actOnDocumentAdd(PathRef File,


### PR DESCRIPTION
Fixes the issue described in comment https://github.com/nix-community/vscode-nix-ide/issues/497#issuecomment-3316236257.