### PR TITLE
libnixf/package: fix `meta.mainProgram`

### DIFF
--- a/libnixf/default.nix
+++ b/libnixf/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
   ];
 
   meta = {
-    mainProgram = "nixf";
+    mainProgram = "nixf-tidy";
     description = "Nix language frontend, parser & semantic analysis";
     homepage = "https://github.com/nix-community/nixd";
     license = lib.licenses.lgpl3Plus;


### PR DESCRIPTION
There is no `nixf` binary provided by this derivation. There is a `nixf-tidy` executable.