### PR TITLE
libnixf/Sema: only flag warnings if user try to override "prelude" builtins

### DIFF
--- a/libnixf/src/Sema/VariableLookup.cpp
+++ b/libnixf/src/Sema/VariableLookup.cpp
@@ -44,7 +44,7 @@ public:
   add(std::string Name, const Node *Entry, Definition::DefinitionSource Source,
       bool IsInheritFromBuiltin) {
     auto PrimOpLookup = lookupGlobalPrimOpInfo(Name);
-    if (PrimOpLookup != PrimopLookupResult::NotFound && !IsInheritFromBuiltin) {
+    if (PrimOpLookup == PrimopLookupResult::Found && !IsInheritFromBuiltin) {
       // Overriding a builtin primop is discouraged.
       Diagnostic &D =
           Diags.emplace_back(Diagnostic::DK_PrimOpOverridden, Entry->range());


### PR DESCRIPTION
Accept builtins that are namespaced (e.g., builtins.path), but overriding "prelude"-builtins (e.g., `map`, `__lessThan`) should still warn.

Fixes: https://github.com/nix-community/nixd/issues/747
Related: https://github.com/nix-community/nixvim/pull/4121


CC @khaneliman, @MattSturgeon, @wolfgangwalther