### PR TITLE
.github/CODEOWNERS: add @takeokunn as code owner for nixd code actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,8 @@
 # Packaging
 /*.nix @Ruixi-rebirth
 /flake.nix @Ruixi-rebirth
+
+
+# Code Actions
+/nixd/lib/Controller/CodeAction.cpp @takeokunn
+/nixd/tools/nixd/test/code-action/ @takeokunn


### PR DESCRIPTION

It is my honor to officially appoint @takeokunn as the Code Owner for the **Code Actions** subsystem.

@takeokunn has been instrumental in building and refining our Code Action capabilities. At this point, he has a mastery of the underlying algorithms and implementation details that is second to none. His dedication and technical insights have been a cornerstone of `nixd`'s recent progress.

By adding him to `.github/CODEOWNERS`, I am entrusting him with the review and architectural oversight of this module. I am confident that under his guidance, our Code Actions will continue to evolve and remain robust.

Huge thanks to @takeokunn for the incredible work so far! Looking forward to seeing where you take this next.