### PR TITLE
nixd/format: only prompt save when formatter really changed the code

### DIFF
--- a/nixd/lib/Controller/Format.cpp
+++ b/nixd/lib/Controller/Format.cpp
@@ -89,6 +89,11 @@ void Controller::onFormat(const DocumentFormattingParams &Params,
       Response.append(Buf, Read);
     }
 
+    if (Response == Code) {
+      Reply(std::vector<TextEdit>{});
+      return;
+    }
+
     TextEdit E{{{0, 0}, {INT_MAX, INT_MAX}}, Response};
     Reply(std::vector{E});
   };


### PR DESCRIPTION
Note this save indicator when I trigger formatter

<img width="1237" height="713" alt="image" src="https://github.com/user-attachments/assets/196e70bf-14c4-4ef4-b8bf-c3987c4f8061" />

Before:

[Screencast_20260112_181229.webm](https://github.com/user-attachments/assets/9c061b5e-3125-4248-b2af-455f2c002091)

After:

[Screencast_20260112_181742.webm](https://github.com/user-attachments/assets/23f4b69f-5f39-4f60-98c2-09135d742618)

