### PR TITLE
nixd: fix boost-1.89 build failure

### DIFF
--- a/nixd/include/nixd/Controller/Controller.h
+++ b/nixd/include/nixd/Controller/Controller.h
@@ -140,10 +140,14 @@ private:
     return TU ? getAST(*TU) : nullptr;
   }
 
-  // Default constructor is broken in Boost 1.87:
+#if BOOST_VERSION < 108800
+  // Default constructor is broken in Boost 1.87, fixed in 1.88:
   // https://github.com/boostorg/asio/commit/30b5974ed34bfa321d268b3135ffaffcb261461a
   boost::asio::thread_pool Pool{
       static_cast<size_t>(boost::asio::detail::default_thread_pool_size())};
+#else
+  boost::asio::thread_pool Pool{};
+#endif
 
   /// Action right after a document is added (including updates).
   void actOnDocumentAdd(lspserver::PathRef File,


### PR DESCRIPTION
With `boost-1.89` `nixd` started failing to build as:

```
nixd> In file included from ../lib/Controller/Diagnostics.cpp:8:
nixd> ../include/nixd/Controller/Controller.h:146:48: error: 'default_thread_pool_size' is not a member of 'boost::asio::detail'
nixd>   146 |       static_cast<size_t>(boost::asio::detail::default_thread_pool_size())};
nixd>       |                                                ^~~~~~~~~~~~~~~~~~~~~~~~
```

Looks like corresponding `boost` code change is
https://github.com/boostorg/asio/commit/0a662cb309e9f490ea8be9edc40a9a9692a14e31

Let's switch back default thread pool initialization for `boost-1.88`
and above.

Tested on `boost-1.87` and `boost-1.89` as:

    $ meson setup .. -Dwerror=false --buildtype=release -Db_sanitize=none -Db_ndebug=true && meson compile && meson test

Both pass the tests.

Closes: https://github.com/nix-community/nixd/issues/732