### PR TITLE
nixd/Completion: fix isIncomplete flag handling

### DIFF
--- a/nixd/lib/Controller/Completion.cpp
+++ b/nixd/lib/Controller/Completion.cpp
@@ -42,10 +42,10 @@ struct ExceedSizeError : std::exception {
 };
 
 void addItem(std::vector<CompletionItem> &Items, CompletionItem Item) {
+  Items.emplace_back(std::move(Item));
   if (Items.size() >= MaxCompletionSize) {
     throw ExceedSizeError();
   }
-  Items.emplace_back(std::move(Item));
 }
 
 bool hasConcreteChild(const Node &N) {

--- a/nixd/tools/nixd/test/completion/options-incomplete.md
+++ b/nixd/tools/nixd/test/completion/options-incomplete.md
@@ -62,7 +62,7 @@
      CHECK: "id": 1,
 CHECK-NEXT:  "jsonrpc": "2.0",
 CHECK-NEXT:  "result": {
-CHECK-NEXT:    "isIncomplete": false,
+CHECK-NEXT:    "isIncomplete": true,
 ```
 
 


### PR DESCRIPTION
When typing a attribute like services.x only the first 30 solutions would be displayed and the isIncomplete flag was always set to false. Moving the bounds check fixed this and isincomplete can now be true.