### PR TITLE
feat(code-action): add quickfix to remove extra rec keyword

### DIFF
--- a/nixd/lib/Controller/CodeAction.cpp
+++ b/nixd/lib/Controller/CodeAction.cpp
@@ -51,6 +51,7 @@ void Controller::onCodeAction(const lspserver::CodeActionParams &Params,
         bool IsPreferred = false;
         switch (D.kind()) {
         case nixf::Diagnostic::DK_UnusedDefLet:
+        case nixf::Diagnostic::DK_ExtraRecursive:
           IsPreferred = true;
           break;
         default:

--- a/nixd/tools/nixd/test/code-action/extra-rec/basic.md
+++ b/nixd/tools/nixd/test/code-action/extra-rec/basic.md
@@ -1,0 +1,78 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+Test basic `remove extra rec` action for unnecessary recursive attribute set.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///extra-rec.nix
+rec { x = 1; }
+```
+
+<-- textDocument/codeAction(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/codeAction",
+   "params":{
+      "textDocument":{
+         "uri":"file:///extra-rec.nix"
+      },
+      "range":{
+         "start":{
+            "line": 0,
+            "character": 0
+         },
+         "end":{
+            "line":0,
+            "character": 3
+         }
+      },
+      "context":{
+         "diagnostics":[],
+         "triggerKind":2
+      }
+   }
+}
+```
+
+The action should remove the `rec` keyword since no binding references another.
+
+```
+     CHECK: "id": 2,
+     CHECK: "newText": "",
+     CHECK: "range":
+     CHECK:   "end":
+     CHECK:     "character": 3,
+     CHECK:     "line": 0
+     CHECK:   "start":
+     CHECK:     "character": 0,
+     CHECK:     "line": 0
+     CHECK: "isPreferred": true,
+     CHECK: "kind": "quickfix",
+     CHECK: "title": "remove `rec` keyword"
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/code-action/extra-rec/empty-rec.md
+++ b/nixd/tools/nixd/test/code-action/extra-rec/empty-rec.md
@@ -1,0 +1,78 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+Test `remove extra rec` action for empty recursive attribute set.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///empty-rec.nix
+rec { }
+```
+
+<-- textDocument/codeAction(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/codeAction",
+   "params":{
+      "textDocument":{
+         "uri":"file:///empty-rec.nix"
+      },
+      "range":{
+         "start":{
+            "line": 0,
+            "character": 0
+         },
+         "end":{
+            "line":0,
+            "character": 3
+         }
+      },
+      "context":{
+         "diagnostics":[],
+         "triggerKind":2
+      }
+   }
+}
+```
+
+The action should remove the `rec` keyword since the attrset has no bindings at all.
+
+```
+     CHECK: "id": 2,
+     CHECK: "newText": "",
+     CHECK: "range":
+     CHECK:   "end":
+     CHECK:     "character": 3,
+     CHECK:     "line": 0
+     CHECK:   "start":
+     CHECK:     "character": 0,
+     CHECK:     "line": 0
+     CHECK: "isPreferred": true,
+     CHECK: "kind": "quickfix",
+     CHECK: "title": "remove `rec` keyword"
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/code-action/extra-rec/multiline.md
+++ b/nixd/tools/nixd/test/code-action/extra-rec/multiline.md
@@ -1,0 +1,81 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+Test `remove extra rec` action with multiline attribute set.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///extra-rec-multiline.nix
+rec {
+  x = 1;
+  y = 2;
+}
+```
+
+<-- textDocument/codeAction(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/codeAction",
+   "params":{
+      "textDocument":{
+         "uri":"file:///extra-rec-multiline.nix"
+      },
+      "range":{
+         "start":{
+            "line": 0,
+            "character": 0
+         },
+         "end":{
+            "line":0,
+            "character": 3
+         }
+      },
+      "context":{
+         "diagnostics":[],
+         "triggerKind":2
+      }
+   }
+}
+```
+
+The action should remove the `rec` keyword since neither `x` nor `y` references the other.
+
+```
+     CHECK: "id": 2,
+     CHECK: "newText": "",
+     CHECK: "range":
+     CHECK:   "end":
+     CHECK:     "character": 3,
+     CHECK:     "line": 0
+     CHECK:   "start":
+     CHECK:     "character": 0,
+     CHECK:     "line": 0
+     CHECK: "isPreferred": true,
+     CHECK: "kind": "quickfix",
+     CHECK: "title": "remove `rec` keyword"
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/code-action/extra-rec/needed-rec.md
+++ b/nixd/tools/nixd/test/code-action/extra-rec/needed-rec.md
@@ -1,0 +1,69 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+Test that `remove extra rec` is NOT offered when `rec` is actually needed.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///needed-rec.nix
+rec { x = 1; y = x; }
+```
+
+<-- textDocument/codeAction(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/codeAction",
+   "params":{
+      "textDocument":{
+         "uri":"file:///needed-rec.nix"
+      },
+      "range":{
+         "start":{
+            "line": 0,
+            "character": 0
+         },
+         "end":{
+            "line":0,
+            "character": 3
+         }
+      },
+      "context":{
+         "diagnostics":[],
+         "triggerKind":2
+      }
+   }
+}
+```
+
+No code action should be offered because `y` depends on `x`, making `rec` necessary.
+
+```
+     CHECK: "id": 2,
+CHECK-NEXT: "jsonrpc": "2.0",
+CHECK-NEXT: "result": []
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```


### PR DESCRIPTION
## Summary

Add a code action that removes unnecessary `rec` keywords from attribute sets, marked as a preferred quickfix.

**Example Transformation:**

| Before              | After           |
|---------------------|-----------------|
| `rec { x = 1; }`   | `{ x = 1; }`   |

## Changes

| File                                    | Description                                |
|-----------------------------------------|--------------------------------------------|
| `nixd/lib/Controller/CodeAction.cpp`    | Mark `DK_ExtraRecursive` as isPreferred    |

## Behavior

Action offered when:

- Cursor is on a `rec` keyword where no binding references another binding in the same attrset

Action NOT offered when:

- Bindings reference each other (e.g., `rec { x = 1; y = x; }`)

## Test Plan

- [x] All 3 extra-rec tests pass
- [x] Build with sanitizers succeeds
- Tests cover:
  - `basic.md`: Single-line `rec { x = 1; }` removal
  - `multiline.md`: Multiline attrset with independent bindings
  - `needed-rec.md`: **Negative test** — action not offered when `rec` is needed

## Related

- Issue: #466
- Draft PR: #755 (this implements Split 14)
