### PR TITLE
feat(code-action): add quickfix to remove extra with expression

### DIFF
--- a/nixd/lib/Controller/CodeAction.cpp
+++ b/nixd/lib/Controller/CodeAction.cpp
@@ -51,6 +51,7 @@ void Controller::onCodeAction(const lspserver::CodeActionParams &Params,
         bool IsPreferred = false;
         switch (D.kind()) {
         case nixf::Diagnostic::DK_UnusedDefLet:
+        case nixf::Diagnostic::DK_ExtraWith:
           IsPreferred = true;
           break;
         default:

--- a/nixd/tools/nixd/test/code-action/extra-with/basic.md
+++ b/nixd/tools/nixd/test/code-action/extra-with/basic.md
@@ -1,0 +1,78 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+Test basic `remove extra with` action for unused with expression.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///extra-with.nix
+with {}; 1
+```
+
+<-- textDocument/codeAction(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/codeAction",
+   "params":{
+      "textDocument":{
+         "uri":"file:///extra-with.nix"
+      },
+      "range":{
+         "start":{
+            "line": 0,
+            "character":0
+         },
+         "end":{
+            "line":0,
+            "character":4
+         }
+      },
+      "context":{
+         "diagnostics":[],
+         "triggerKind":2
+      }
+   }
+}
+```
+
+The action should remove `with {};` leaving just `1`.
+
+```
+     CHECK: "id": 2,
+     CHECK: "newText": "",
+     CHECK: "range":
+     CHECK:   "end":
+     CHECK:     "character": 4,
+     CHECK:     "line": 0
+     CHECK:   "start":
+     CHECK:     "character": 0,
+     CHECK:     "line": 0
+     CHECK: "isPreferred": true,
+     CHECK: "kind": "quickfix",
+     CHECK: "title": "remove `with` expression"
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/code-action/extra-with/multiline.md
+++ b/nixd/tools/nixd/test/code-action/extra-with/multiline.md
@@ -1,0 +1,77 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+Test `remove extra with` action with multiline expression.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///multiline-with.nix
+with lib;
+1 + 2
+```
+
+<-- textDocument/codeAction(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/codeAction",
+   "params":{
+      "textDocument":{
+         "uri":"file:///multiline-with.nix"
+      },
+      "range":{
+         "start":{
+            "line": 0,
+            "character":0
+         },
+         "end":{
+            "line":0,
+            "character":4
+         }
+      },
+      "context":{
+         "diagnostics":[],
+         "triggerKind":2
+      }
+   }
+}
+```
+
+The action should remove the `with lib;` part.
+
+```
+     CHECK: "id": 2,
+     CHECK: "newText": "",
+     CHECK: "range":
+     CHECK:   "end":
+     CHECK:     "line": 0
+     CHECK:   "start":
+     CHECK:     "line": 0
+     CHECK: "isPreferred": true,
+     CHECK: "kind": "quickfix",
+     CHECK: "title": "remove `with` expression"
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/code-action/extra-with/needed-with.md
+++ b/nixd/tools/nixd/test/code-action/extra-with/needed-with.md
@@ -1,0 +1,69 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+Test that `remove extra with` action is NOT offered when with is actually used.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///needed-with.nix
+with lib; foo
+```
+
+<-- textDocument/codeAction(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/codeAction",
+   "params":{
+      "textDocument":{
+         "uri":"file:///needed-with.nix"
+      },
+      "range":{
+         "start":{
+            "line": 0,
+            "character":0
+         },
+         "end":{
+            "line":0,
+            "character":4
+         }
+      },
+      "context":{
+         "diagnostics":[],
+         "triggerKind":2
+      }
+   }
+}
+```
+
+No "remove `with` expression" action should be offered because `foo` is
+resolved through the `with lib` scope.
+
+```
+         CHECK: "id": 2,
+     CHECK-NOT: "remove `with` expression"
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```


### PR DESCRIPTION
## Summary

Add the "remove extra `with` expression" quickfix as a preferred code action.

## Changes

- Mark `DK_ExtraWith` diagnostic fixes as `isPreferred` in CodeAction.cpp

## Behavior

Unused `with` → quickfix offered with isPreferred: true
- Used `with` → no removal action offered

## Test Plan

- basic.md, multiline.md, needed-with.md

## Related

- Planned Split 15 from #755
- Follows pattern of #785 and #779
