### PR TITLE
feat(code-action): add quickfix to remove empty inherit

### DIFF
--- a/nixd/lib/Controller/CodeAction.cpp
+++ b/nixd/lib/Controller/CodeAction.cpp
@@ -51,6 +51,7 @@ void Controller::onCodeAction(const lspserver::CodeActionParams &Params,
         bool IsPreferred = false;
         switch (D.kind()) {
         case nixf::Diagnostic::DK_UnusedDefLet:
+        case nixf::Diagnostic::DK_EmptyInherit:
           IsPreferred = true;
           break;
         default:

--- a/nixd/tools/nixd/test/code-action/empty-inherit/empty-inherit.md
+++ b/nixd/tools/nixd/test/code-action/empty-inherit/empty-inherit.md
@@ -1,0 +1,107 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+Test that `inherit;` (empty inherit) gets a quickfix to remove it.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///empty-inherit.nix
+{ inherit; }
+```
+
+<-- textDocument/codeAction(1)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":1,
+   "method":"textDocument/codeAction",
+   "params":{
+      "textDocument":{
+         "uri":"file:///empty-inherit.nix"
+      },
+      "range":{
+         "start":{
+            "line": 0,
+            "character":2
+         },
+         "end":{
+            "line":0,
+            "character":9
+         }
+      },
+      "context":{
+         "diagnostics":[],
+         "triggerKind":2
+      }
+   }
+}
+```
+
+The action removes both `inherit` and `;`, producing `{  }`.
+
+```
+     CHECK:   "id": 1,
+CHECK-NEXT:   "jsonrpc": "2.0",
+CHECK-NEXT:   "result": [
+CHECK-NEXT:     {
+CHECK-NEXT:       "edit": {
+CHECK-NEXT:         "changes": {
+CHECK-NEXT:           "file:///empty-inherit.nix": [
+CHECK-NEXT:             {
+CHECK-NEXT:               "newText": "",
+CHECK-NEXT:               "range": {
+CHECK-NEXT:                 "end": {
+CHECK-NEXT:                   "character": 9,
+CHECK-NEXT:                   "line": 0
+CHECK-NEXT:                 },
+CHECK-NEXT:                 "start": {
+CHECK-NEXT:                   "character": 2,
+CHECK-NEXT:                   "line": 0
+CHECK-NEXT:                 }
+CHECK-NEXT:               }
+CHECK-NEXT:             },
+CHECK-NEXT:             {
+CHECK-NEXT:               "newText": "",
+CHECK-NEXT:               "range": {
+CHECK-NEXT:                 "end": {
+CHECK-NEXT:                   "character": 10,
+CHECK-NEXT:                   "line": 0
+CHECK-NEXT:                 },
+CHECK-NEXT:                 "start": {
+CHECK-NEXT:                   "character": 9,
+CHECK-NEXT:                   "line": 0
+CHECK-NEXT:                 }
+CHECK-NEXT:               }
+CHECK-NEXT:             }
+CHECK-NEXT:           ]
+CHECK-NEXT:         }
+CHECK-NEXT:       },
+CHECK-NEXT:       "isPreferred": true,
+CHECK-NEXT:       "kind": "quickfix",
+CHECK-NEXT:       "title": "remove `inherit` keyword"
+CHECK-NEXT:     }
+CHECK-NEXT:   ]
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```


### PR DESCRIPTION
## Summary

Add a **quickfix code action** that removes empty `inherit;` statements from Nix code.

| Before | After |
|--------|-------|
| `{ inherit; }` | `{  }` |

## Changes

- **`nixd/lib/Controller/CodeAction.cpp`**: Mark `DK_EmptyInherit` as `isPreferred` in the code action handler, so the existing diagnostic fix surfaces as a preferred quickfix in LSP clients.

## Behavior

The `DK_EmptyInherit` diagnostic and its associated fix (removing both the `inherit` keyword and its `;` semicolon) already exist in `libnixf`. This PR wires it into the LSP code action response with `isPreferred: true`, matching the pattern used by `DK_UnusedDefLet`.

## Test Plan

- Added `nixd/tools/nixd/test/code-action/empty-inherit/empty-inherit.md` — lit test verifying the quickfix removes `inherit;` and returns the expected edit range with `isPreferred: true`.

## Related

- Part of #466 (code actions tracking issue)
- Split 16 of #755