### PR TITLE
feat(code-action): add quickfix to remove redundant parentheses

### DIFF
--- a/nixd/lib/Controller/CodeAction.cpp
+++ b/nixd/lib/Controller/CodeAction.cpp
@@ -51,6 +51,7 @@ void Controller::onCodeAction(const lspserver::CodeActionParams &Params,
         bool IsPreferred = false;
         switch (D.kind()) {
         case nixf::Diagnostic::DK_UnusedDefLet:
+        case nixf::Diagnostic::DK_RedundantParen:
           IsPreferred = true;
           break;
         default:

--- a/nixd/tools/nixd/test/code-action/redundant-paren/basic.md
+++ b/nixd/tools/nixd/test/code-action/redundant-paren/basic.md
@@ -1,0 +1,86 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+Test basic `remove redundant parens` action for unnecessary parentheses.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///redundant-paren.nix
+(1)
+```
+
+<-- textDocument/codeAction(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/codeAction",
+   "params":{
+      "textDocument":{
+         "uri":"file:///redundant-paren.nix"
+      },
+      "range":{
+         "start":{
+            "line": 0,
+            "character": 0
+         },
+         "end":{
+            "line":0,
+            "character": 1
+         }
+      },
+      "context":{
+         "diagnostics":[],
+         "triggerKind":2
+      }
+   }
+}
+```
+
+The action should remove both `(` and `)` since the inner expression `1` is simple.
+
+```
+     CHECK: "id": 2,
+     CHECK: "newText": "",
+     CHECK: "range":
+     CHECK:   "end":
+     CHECK:     "character": 1,
+     CHECK:     "line": 0
+     CHECK:   "start":
+     CHECK:     "character": 0,
+     CHECK:     "line": 0
+     CHECK: "newText": "",
+     CHECK: "range":
+     CHECK:   "end":
+     CHECK:     "character": 3,
+     CHECK:     "line": 0
+     CHECK:   "start":
+     CHECK:     "character": 2,
+     CHECK:     "line": 0
+     CHECK: "isPreferred": true,
+     CHECK: "kind": "quickfix",
+     CHECK: "title": "remove ( and )"
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/code-action/redundant-paren/multiline.md
+++ b/nixd/tools/nixd/test/code-action/redundant-paren/multiline.md
@@ -1,0 +1,88 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+Test `remove redundant parens` action with multiline expression.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///multiline-paren.nix
+(
+  1
+)
+```
+
+<-- textDocument/codeAction(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/codeAction",
+   "params":{
+      "textDocument":{
+         "uri":"file:///multiline-paren.nix"
+      },
+      "range":{
+         "start":{
+            "line": 0,
+            "character": 0
+         },
+         "end":{
+            "line":0,
+            "character": 1
+         }
+      },
+      "context":{
+         "diagnostics":[],
+         "triggerKind":2
+      }
+   }
+}
+```
+
+The action should remove `(` on line 0 and `)` on line 2.
+
+```
+     CHECK: "id": 2,
+     CHECK: "newText": "",
+     CHECK: "range":
+     CHECK:   "end":
+     CHECK:     "character": 1,
+     CHECK:     "line": 0
+     CHECK:   "start":
+     CHECK:     "character": 0,
+     CHECK:     "line": 0
+     CHECK: "newText": "",
+     CHECK: "range":
+     CHECK:   "end":
+     CHECK:     "character": 1,
+     CHECK:     "line": 2
+     CHECK:   "start":
+     CHECK:     "character": 0,
+     CHECK:     "line": 2
+     CHECK: "isPreferred": true,
+     CHECK: "kind": "quickfix",
+     CHECK: "title": "remove ( and )"
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/code-action/redundant-paren/needed-paren.md
+++ b/nixd/tools/nixd/test/code-action/redundant-paren/needed-paren.md
@@ -1,0 +1,69 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+Test that `remove redundant parens` is NOT offered when parentheses are needed.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///needed-paren.nix
+(1 + 2)
+```
+
+<-- textDocument/codeAction(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/codeAction",
+   "params":{
+      "textDocument":{
+         "uri":"file:///needed-paren.nix"
+      },
+      "range":{
+         "start":{
+            "line": 0,
+            "character": 0
+         },
+         "end":{
+            "line":0,
+            "character": 1
+         }
+      },
+      "context":{
+         "diagnostics":[],
+         "triggerKind":2
+      }
+   }
+}
+```
+
+No code action should be offered because `1 + 2` is a binary operation, making parentheses meaningful.
+
+```
+     CHECK: "id": 2,
+CHECK-NEXT: "jsonrpc": "2.0",
+CHECK-NEXT: "result": []
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/code-action/redundant-paren/nested.md
+++ b/nixd/tools/nixd/test/code-action/redundant-paren/nested.md
@@ -1,0 +1,73 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+Test `remove redundant parens` action for nested parentheses `((1))`.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///nested-paren.nix
+((1))
+```
+
+<-- textDocument/codeAction(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/codeAction",
+   "params":{
+      "textDocument":{
+         "uri":"file:///nested-paren.nix"
+      },
+      "range":{
+         "start":{
+            "line": 0,
+            "character": 0
+         },
+         "end":{
+            "line":0,
+            "character": 5
+         }
+      },
+      "context":{
+         "diagnostics":[],
+         "triggerKind":2
+      }
+   }
+}
+```
+
+Both inner and outer parentheses are redundant, so two quickfix actions should be offered.
+
+```
+     CHECK: "id": 2,
+     CHECK: "isPreferred": true,
+     CHECK: "kind": "quickfix",
+     CHECK: "title": "remove ( and )"
+     CHECK: "isPreferred": true,
+     CHECK: "kind": "quickfix",
+     CHECK: "title": "remove ( and )"
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```


### PR DESCRIPTION
## Summary

Add code action to remove redundant parentheses from Nix expressions.

**Example Transformation:**

| Before    | After |
|-----------|-------|
| `(1)`     | `1`   |
| `((1))`   | `(1)` then `1` (two separate actions) |
| `(x)`     | `x`   |
| `({ })`   | `{ }` |

# Changes

| File                                 | Description                                          |
|--------------------------------------|------------------------------------------------------|
| `nixd/lib/Controller/CodeAction.cpp` | Set `isPreferred: true` for redundant paren quickfix |

## Behavior

**Action offered when:**
- Cursor is on a parenthesized expression wrapping a "simple" form
- Simple forms: variable, integer, float, string, path, search path, paren, attribute set, list

**Action NOT offered when:**
- Inner expression requires parentheses for disambiguation (binary ops, if-then-else, lambda, let, with, etc.)

**Handles removal:**
- Removes both `(` and `)` with two `TextEdit::mkRemoval` edits
- Works with single-line and multiline expressions

## Test Plan

- [x] All 4 redundant-paren tests pass
- [x] Build succeeds
- Tests cover:
  - `basic.md`: Remove parens around integer literal `(1)`
  - `nested.md`: Double-nested `((1))` produces two quickfix actions
  - `multiline.md`: Multiline paren removal across lines
  - `needed-paren.md`: **Negative** - `(1 + 2)` does NOT offer action

## Related

- Issue: #466
- Draft PR: #755 (this implements Split 17)
