### PR TITLE
Bump nixpkgs flake input, update nix 2.30 -> 2.33

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
@@ -35,30 +35,30 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754800730,
-        "narHash": "sha256-HfVZCXic9XLBgybP0318ym3cDnGwBs/+H5MgxFVYF4I=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "641d909c4a7538f1539da9240dedb1755c907e40",
-        "type": "github"
+        "lastModified": 1772963539,
+        "narHash": "sha256-G4+9cEu8XSqEWYUB6iRgDfrg53av6yyRwAKhSeKbUVw=",
+        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre960399.9dcb002ca169/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1733096140,
-        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734704479,
-        "narHash": "sha256-MMi74+WckoyEWBRcg/oaGRvXC9BVVxDZNRMpL+72wBI=",
+        "lastModified": 1772660329,
+        "narHash": "sha256-IjU1FxYqm+VDe5qIOxoW+pISBlGvVApRjiw/Y/ttJzY=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "65712f5af67234dad91a5a4baee986a8b62dbf8f",
+        "rev": "3710e0e1218041bbad640352a0440114b1e10428",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,12 +29,12 @@
         let
           inherit (pkgs)
             nixVersions
-            llvmPackages_19
+            llvmPackages_21
             callPackage
             stdenv
             ;
           nixComponents = nixVersions.nixComponents_2_30;
-          llvmPackages = llvmPackages_19;
+          llvmPackages = llvmPackages_21;
           nixf = callPackage ./libnixf { inherit (nixComponents) nix-expr; };
           nixt = callPackage ./libnixt { inherit nixComponents; };
           nixd = callPackage ./nixd {

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
             callPackage
             stdenv
             ;
-          nixComponents = nixVersions.nixComponents_2_30;
+          nixComponents = nixVersions.nixComponents_2_33;
           llvmPackages = llvmPackages_21;
           nixf = callPackage ./libnixf { inherit (nixComponents) nix-expr; };
           nixt = callPackage ./libnixt { inherit nixComponents; };

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
 
     flake-parts.url = "github:hercules-ci/flake-parts";
 
@@ -46,7 +46,7 @@
           regressionDeps = with pkgs; [
             clang-tools
             lit
-            nixfmt-rfc-style
+            nixfmt
           ];
           shellOverride = old: {
             nativeBuildInputs = old.nativeBuildInputs ++ regressionDeps;
@@ -75,7 +75,7 @@
           devShells.nvim = pkgs.mkShell {
             nativeBuildInputs = [
               nixd
-              pkgs.nixfmt-rfc-style
+              pkgs.nixfmt
               pkgs.git
               (import ./nixd/docs/editors/nvim-lsp.nix { inherit pkgs; })
             ];
@@ -112,7 +112,7 @@
           devShells.vscodium = pkgs.mkShell {
             nativeBuildInputs = [
               nixd
-              pkgs.nixfmt-rfc-style
+              pkgs.nixfmt
               (import ./nixd/docs/editors/vscodium.nix { inherit pkgs; })
             ];
           };

--- a/libnixf/src/Basic/PrimOpsInfoGen.cpp
+++ b/libnixf/src/Basic/PrimOpsInfoGen.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
     std::cout << "    .Arity = " << PrimOp.arity << ",\n";
 
     // .doc
-    std::cout << "    .Doc = R\"xabc(" << (PrimOp.doc ? PrimOp.doc : "")
+    std::cout << "    .Doc = R\"xabc(" << PrimOp.doc.value_or("")
               << ")xabc\",\n";
 
     // .internal

--- a/libnixt/include/nixt/InitEval.h
+++ b/libnixt/include/nixt/InitEval.h
@@ -8,6 +8,7 @@
 #include <nix/flake/settings.hh>
 #include <nix/main/plugin.hh>
 #include <nix/main/shared.hh>
+#include <nix/store/globals.hh>
 #include <nix/store/store-api.hh>
 
 namespace nixt {

--- a/libnixt/lib/Value.cpp
+++ b/libnixt/lib/Value.cpp
@@ -14,7 +14,7 @@ std::optional<nix::Value> nixt::getField(nix::EvalState &State, nix::Value &V,
     return std::nullopt;
 
   nix::Symbol SFiled = State.symbols.create(Field);
-  if (auto *It = V.attrs()->find(SFiled); It != V.attrs()->end())
+  if (const auto *It = V.attrs()->get(SFiled))
     return *It->value;
 
   return std::nullopt;
@@ -53,7 +53,7 @@ bool nixt::isDerivation(nix::EvalState &State, nix::Value &V) {
 
 std::string nixt::attrPathStr(nix::EvalState &State, nix::Value &V,
                               const std::string &AttrPath) {
-  auto &AutoArgs = *State.allocBindings(0);
+  auto &AutoArgs = nix::Bindings::emptyBindings;
   auto [VPath, Pos] = nix::findAlongAttrPath(State, AttrPath, AutoArgs, V);
   State.forceValue(*VPath, Pos);
   return std::string(State.forceStringNoCtx(*VPath, nix::noPos, ""));
@@ -89,8 +89,8 @@ nix::Value &nixt::selectAttr(nix::EvalState &State, nix::Value &V,
     throw nix::TypeError(State, "value is not an attrset");
 
   assert(V.attrs() && "nix must allocate non-null attrs!");
-  auto *Nested = V.attrs()->find(Attr);
-  if (Nested == V.attrs()->end())
+  const auto *Nested = V.attrs()->get(Attr);
+  if (!Nested)
     throw nix::AttrPathNotFound("attrname " + State.symbols[Attr] +
                                 " not found in attrset");
 
@@ -102,7 +102,7 @@ nix::Value &nixt::selectAttr(nix::EvalState &State, nix::Value &V,
 nix::Value &nixt::selectAttrPath(nix::EvalState &State, nix::Value &V,
                                  std::vector<nix::Symbol>::const_iterator Begin,
                                  std::vector<nix::Symbol>::const_iterator End) {
-  // If the attrpath is emtpy, return value itself.
+  // If the attrpath is empty, return value itself.
   if (Begin == End)
     return V;
 
@@ -120,7 +120,7 @@ bool isTypeSubmodule(nix::EvalState &State, nix::Value &Type) {
 
 nix::Value *trySelectAttr(nix::EvalState &State, nix::Value &V, nix::Symbol S) {
   try {
-    nix::Value &Type = selectAttr(State, V, State.sType);
+    nix::Value &Type = selectAttr(State, V, nix::EvalState::s.type);
     return &Type;
   } catch (nix::TypeError &) {
     // The value is not an attrset, thus it definitely cannot be a submodule.
@@ -134,7 +134,7 @@ nix::Value *trySelectAttr(nix::EvalState &State, nix::Value &V, nix::Symbol S) {
 
 /// \brief Get the type of an option.
 nix::Value *tryGetSubmoduleType(nix::EvalState &State, nix::Value &V) {
-  if (nix::Value *Type = trySelectAttr(State, V, State.sType))
+  if (nix::Value *Type = trySelectAttr(State, V, nix::EvalState::s.type))
     return isTypeSubmodule(State, *Type) ? Type : nullptr;
   return nullptr;
 }
@@ -174,7 +174,7 @@ nix::Value nixt::selectOptions(nix::EvalState &State, nix::Value &V,
     //      networking.interfaces
     //
     // Take care of such case.
-    nix::Value &Type = selectAttr(State, V, State.sType);
+    nix::Value &Type = selectAttr(State, V, nix::EvalState::s.type);
     if (checkField(State, Type, "name", "attrsOf")) {
       nix::Value NestedTypes =
           selectAttr(State, Type, State.symbols.create("nestedTypes"));

--- a/nixd/lib/Eval/AttrSetProvider.cpp
+++ b/nixd/lib/Eval/AttrSetProvider.cpp
@@ -137,15 +137,13 @@ void fillOptionDescription(nix::EvalState &State, nix::Value &V,
   // FIXME: add definitions location.
   if (V.type() == nix::ValueType::nAttrs) [[likely]] {
     assert(V.attrs());
-    if (auto *It = V.attrs()->find(State.symbols.create("type"));
-        It != V.attrs()->end()) [[likely]] {
+    if (auto *It = V.attrs()->get(State.symbols.create("type"))) [[likely]] {
       OptionType Type;
       fillOptionType(State, *It->value, Type);
       R.Type = std::move(Type);
     }
 
-    if (auto *It = V.attrs()->find(State.symbols.create("example"));
-        It != V.attrs()->end()) {
+    if (auto *It = V.attrs()->get(State.symbols.create("example"))) {
       State.forceValue(*It->value, It->pos);
 
       // In nixpkgs some examples are nested in "literalExpression"
@@ -190,7 +188,7 @@ std::optional<ValueDescription> describeValue(nix::EvalState &State,
     const auto *PrimOp = V.primOp();
     assert(PrimOp);
     return ValueDescription{
-        .Doc = PrimOp->doc ? std::string(PrimOp->doc) : "",
+        .Doc = PrimOp->doc.value_or(""),
         .Arity = static_cast<int>(PrimOp->arity),
         .Args = PrimOp->args,
     };


### PR DESCRIPTION
Pretty straight-forward bump. Updates the nixpkgs flake input and also switch to the more efficient channel tarball which now supports lockable tarball protocol.

I'm not sure if meson should provide an explicit
version range for nix library dependencies - it currently doesn't.

Otherwise, some of the notable changes are that `Bindings::find()` is no longer a thing,
because of the attrset layering optimisation that prohibits us from being able
to return an iterator. Instead all users should consistently use `Bindings::get()` which
returns a nullable pointer.