### PR TITLE
refactor(editor): unify editor test environments and update LSP configs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,21 +18,6 @@
         "type": "github"
       }
     },
-    "flake-root": {
-      "locked": {
-        "lastModified": 1723604017,
-        "narHash": "sha256-rBtQ8gg+Dn4Sx/s+pvjdq3CB2wQNzx9XGFq/JVGCB6k=",
-        "owner": "srid",
-        "repo": "flake-root",
-        "rev": "b759a56851e10cb13f6b8e5698af7b59c44be26e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "flake-root",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1772963539,
@@ -64,7 +49,6 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "flake-root": "flake-root",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,8 +4,6 @@
 
     flake-parts.url = "github:hercules-ci/flake-parts";
 
-    flake-root.url = "github:srid/flake-root";
-
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -22,10 +20,14 @@
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         inputs.flake-parts.flakeModules.easyOverlay
-        inputs.flake-root.flakeModule
       ];
       perSystem =
-        { config, pkgs, ... }:
+        {
+          config,
+          pkgs,
+          lib,
+          ...
+        }:
         let
           inherit (pkgs)
             nixVersions
@@ -57,6 +59,8 @@
             '';
             hardeningDisable = [ "fortify" ];
           };
+          testShell = callPackage ./nixd/docs/editors/test-shell.nix;
+          examplesSrc = ./nixd/docs/examples/NixOS_Home-Manager;
           treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
         in
         {
@@ -68,54 +72,16 @@
             inherit nixd nixf nixt;
           };
 
-          devShells.llvm = nixdLLVM.overrideAttrs shellOverride;
-
-          devShells.default = nixdMono.overrideAttrs shellOverride;
-
-          devShells.nvim = pkgs.mkShell {
-            nativeBuildInputs = [
-              nixd
-              pkgs.nixfmt
-              pkgs.git
-              (import ./nixd/docs/editors/nvim-lsp.nix { inherit pkgs; })
-            ];
-            inputsFrom = [ config.flake-root.devShell ];
-            shellHook = ''
-              echo -e "\n\033[1;31mDuring the first time nixd launches, the flake inputs will be fetched from the internet, this is rather slow.\033[0m"
-              echo -e "\033[1;34mEntering the nvim test environment...\033[0m"
-              cd $FLAKE_ROOT
-              export GIT_REPO=https://github.com/nix-community/nixd.git
-              export EXAMPLES_PATH=nixd/docs/examples
-              export WORK_TEMP=/tmp/NixOS_Home-Manager
-              if [ -d "$WORK_TEMP" ]; then
-              	rm -rf $WORK_TEMP
-              fi
-              mkdir -p $WORK_TEMP
-              cp -r $EXAMPLES_PATH/NixOS_Home-Manager/* $WORK_TEMP/ 2>/dev/null
-              if [[ $? -ne 0 ]]; then
-              	export GIT_DIR=$WORK_TEMP/.git
-              	export GIT_WORK_TREE=/tmp/NixOS_Home-Manager
-              	git init
-              	git config core.sparseCheckout true
-              	git remote add origin $GIT_REPO
-              	echo "$EXAMPLES_PATH/NixOS_Home-Manager/" >$GIT_DIR/info/sparse-checkout
-              	git pull origin main
-              	cp $GIT_WORK_TREE\/$EXAMPLES_PATH/NixOS_Home-Manager/* $GIT_WORK_TREE 2>/dev/null
-              	rm -rf $GIT_WORK_TREE/nixd
-              fi
-              cd $WORK_TEMP
-              echo -e "\033[1;32mNow, you can edit the nix file by running the following command:\033[0m"
-              echo -e "\033[1;33m'nvim-lsp flake.nix'\033[0m"
-              echo -e "\033[1;34mEnvironment setup complete.\033[0m"
-            '';
-          };
-          devShells.vscodium = pkgs.mkShell {
-            nativeBuildInputs = [
-              nixd
-              pkgs.nixfmt
-              (import ./nixd/docs/editors/vscodium.nix { inherit pkgs; })
-            ];
-          };
+          devShells = {
+            llvm = nixdLLVM.overrideAttrs shellOverride;
+            default = nixdMono.overrideAttrs shellOverride;
+          }
+          // lib.genAttrs [ "nvim" "vscodium" ] (
+            editor:
+            testShell {
+              inherit nixd examplesSrc editor;
+            }
+          );
           formatter = treefmtEval.config.build.wrapper;
         };
       systems = nixpkgs.lib.systems.flakeExposed;

--- a/nixd/docs/configuration.md
+++ b/nixd/docs/configuration.md
@@ -73,31 +73,34 @@ For vscode users you should write `settings.json`[^settings] like this:
 <details>
  <summary>Neovim</summary>
 
- Configuration via [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) plugin. If you want to make configuration changes based on different projects, you can see nvim-lspconfig official [wiki-Project_local_settings](https://github.com/neovim/nvim-lspconfig/wiki/Project-local-settings)
+Configuration via Neovim [built-in LSP](https://neovim.io/doc/user/lsp/#lsp). If you want to make configuration changes based on different projects, you can use Neovim official [exrc](https://neovim.io/doc/user/options/#'exrc') option.
 
 ```lua
-local nvim_lsp = require("lspconfig")
-nvim_lsp.nixd.setup({
-   cmd = { "nixd" },
-   settings = {
-      nixd = {
-         nixpkgs = {
-            expr = "import <nixpkgs> { }",
-         },
-         formatting = {
-            command = { "nixfmt" },
-         },
-         options = {
-            nixos = {
-               expr = '(builtins.getFlake ("git+file://" + toString ./.)).nixosConfigurations.k-on.options',
-            },
-            home_manager = {
-               expr = '(builtins.getFlake ("git+file://" + toString ./.)).homeConfigurations."ruixi@k-on".options',
-            },
-         },
+local nvim_lsp = vim.lsp
+nvim_lsp.config("nixd", {
+  cmd = { "nixd" },
+  filetypes = { "nix" },
+  root_markers = { "flake.nix", ".git" },
+  settings = {
+    nixd = {
+      nixpkgs = {
+        expr = "import <nixpkgs> { }",
       },
-   },
+      formatting = {
+        command = { "nixfmt" },
+      },
+      options = {
+        nixos = {
+          expr = '(builtins.getFlake (toString ./.)).nixosConfigurations.<hostname>.options',
+        },
+        home_manager = {
+          expr = '(builtins.getFlake (toString ./.)).homeConfigurations."<username>@<hostname>".options',
+        },
+      },
+    },
+  },
 })
+nvim_lsp.enable("nixd")
 ```
 </details>
 

--- a/nixd/docs/editors/editors.md
+++ b/nixd/docs/editors/editors.md
@@ -9,7 +9,7 @@ Start up the test environment:
 ```console
 nix develop github:nix-community/nixd#vscodium
 
-codium-test
+codium-test .
 ```
 
 ### Neovim
@@ -17,5 +17,5 @@ codium-test
 ```console
 nix develop github:nix-community/nixd#nvim
 
-nvim-lsp flake.nix
+nvim-lsp .
 ```

--- a/nixd/docs/editors/nvim-lsp.nix
+++ b/nixd/docs/editors/nvim-lsp.nix
@@ -4,478 +4,68 @@
 let
   neovim = pkgs.neovim.override {
     configure = {
-      customRC = ''
-        lua <<EOF
-        ${luaRc}
-        EOF
-      '';
-
+      customRC = "lua <<EOF\n${luaRc}\nEOF";
       packages.myPlugins.start = with pkgs.vimPlugins; [
-        (nvim-treesitter.withPlugins (
-          parsers: builtins.attrValues { inherit (parsers) nix markdown markdown_inline; }
-        ))
-        friendly-snippets
-        luasnip
-        nvim-cmp
-        cmp-nvim-lsp
-        cmp-buffer
-        cmp_luasnip
-        cmp-path
-        cmp-cmdline
-        none-ls-nvim
-        nvim-lspconfig
-        nord-nvim
-        noice-nvim
-        lualine-nvim
-        bufferline-nvim
-        lspsaga-nvim
+        (nvim-treesitter.withPlugins (p: [ p.nix ]))
       ];
     };
   };
 
-  # lua
   luaRc = ''
-    -------------------
-    -- Basic options --
-    -------------------
-    local options = {
-    	clipboard = "unnamedplus",
-    	mouse = "a",
-    	undofile = true,
-    	ignorecase = true,
-    	showmode = false,
-    	showtabline = 2,
-    	smartindent = true,
-    	autoindent = true,
-    	swapfile = false,
-    	hidden = true, --default on
-    	expandtab = true,
-    	cmdheight = 1,
-    	shiftwidth = 2, --insert 2 spaces for each indentation
-    	tabstop = 2, --insert 2 spaces for a tab
-    	cursorline = true, --Highlight the line where the cursor is located
-    	cursorcolumn = false,
-    	number = true,
-    	numberwidth = 4,
-    	relativenumber = true,
-    	scrolloff = 8,
-    	updatetime = 50, -- faster completion (4000ms default)
-    	foldmethod = "expr",
-    	foldexpr = "v:lua.vim.lsp.foldexpr()",
-    	foldlevel = 99,
-    	foldenable = true,
-    }
+    vim.opt.number = true
+    vim.opt.shiftwidth = 2
+    vim.opt.expandtab = true
+    vim.opt.completeopt = { "menu", "menuone", "noselect" }
 
-    for k, v in pairs(options) do
-    	vim.opt[k] = v
-    end
-
-    ----------------
-    -- nord theme --
-    ----------------
-    vim.g.nord_contrast = false
-    vim.g.nord_borders = true
-    vim.g.nord_disable_background = false
-    vim.g.nord_italic = true
-    vim.g.nord_uniform_diff_background = true
-    vim.g.nord_enable_sidebar_background = true
-    vim.g.nord_bold = true
-    vim.g.nord_cursorline_transparent = false
-    require("nord").set()
-
-    -----------------
-    -- About noice --
-    -----------------
-    require("noice").setup({
-        routes = {
-            {
-                filter = {
-                    event = "msg_show",
-                    any = {
-                        { find = "%d+L, %d+B" },
-                        { find = "; after #%d+" },
-                        { find = "; before #%d+" },
-                        { find = "%d fewer lines" },
-                        { find = "%d more lines" },
-                    },
-                },
-                opts = { skip = true },
+    local nvim_lsp = vim.lsp
+    local flake_expr = 'builtins.getFlake (toString ./.)'
+    nvim_lsp.config("nixd", {
+      cmd = { "nixd" },
+      filetypes = { "nix" },
+      root_markers = { 'flake.nix', '.git' },
+      settings = {
+        nixd = {
+          nixpkgs = {
+            expr = string.format('import (%s).inputs.nixpkgs { }', flake_expr)
+          },
+          formatting = { command = { "${pkgs.nixfmt}/bin/nixfmt" } },
+          options = {
+            nixos = {
+              expr = string.format('(%s).nixosConfigurations.hostname.options', flake_expr)
             },
-        },
-    })
-
-    -------------------
-    -- About lualine --
-    -------------------
-    require("lualine").setup({
-        options = {
-            theme = "auto",
-            globalstatus = true,
-        },
-    })
-
-    ----------------------
-    -- About bufferline --
-    ----------------------
-    local highlights
-    highlights = require("nord").bufferline.highlights({
-        italic = true,
-        bold = true,
-    })
-    require("bufferline").setup({
-        highlights = highlights,
-    })
-
-    ----------------------
-    -- About treesitter --
-    ----------------------
-    require("nvim-treesitter.configs").setup({
-    	highlight = {
-    		enable = true,
-    	},
-    	indent = {
-    		enable = true,
-    	},
-    })
-
-    ---------------
-    -- About cmp --
-    ---------------
-    local cmp_status_ok, cmp = pcall(require, "cmp")
-    if not cmp_status_ok then
-    	return
-    end
-    local snip_status_ok, luasnip = pcall(require, "luasnip")
-    if not snip_status_ok then
-    	return
-    end
-
-    require("luasnip/loaders/from_vscode").lazy_load()
-
-    local kind_icons = {
-    	Text = "󰊄",
-    	Method = "",
-    	Function = "󰡱",
-    	Constructor = "",
-    	Field = "",
-    	Variable = "󱀍",
-    	Class = "",
-    	Interface = "",
-    	Module = "󰕳",
-    	Property = "",
-    	Unit = "",
-    	Value = "",
-    	Enum = "",
-    	Keyword = "",
-    	Snippet = "",
-    	Color = "",
-    	File = "",
-    	Reference = "",
-    	Folder = "",
-    	EnumMember = "",
-    	Constant = "",
-    	Struct = "",
-    	Event = "",
-    	Operator = "",
-    	TypeParameter = "",
-    }
-    -- find more here: https://www.nerdfonts.com/cheat-sheet
-    cmp.setup({
-    	snippet = {
-    		expand = function(args)
-    			luasnip.lsp_expand(args.body) -- For `luasnip` users.
-    		end,
-    	},
-    	mapping = cmp.mapping.preset.insert({
-    		["<C-u>"] = cmp.mapping.scroll_docs(-4), -- Up
-    		["<C-d>"] = cmp.mapping.scroll_docs(4), -- Down
-    		-- C-b (back) C-f (forward) for snippet placeholder navigation.
-    		["<C-Space>"] = cmp.mapping.complete(),
-    		["<CR>"] = cmp.mapping.confirm({
-    			behavior = cmp.ConfirmBehavior.Replace,
-    			select = true,
-    		}),
-    		["<Tab>"] = cmp.mapping(function(fallback)
-    			if cmp.visible() then
-    				cmp.select_next_item()
-    			elseif luasnip.expand_or_jumpable() then
-    				luasnip.expand_or_jump()
-    			else
-    				fallback()
-    			end
-    		end, { "i", "s" }),
-    		["<S-Tab>"] = cmp.mapping(function(fallback)
-    			if cmp.visible() then
-    				cmp.select_prev_item()
-    			elseif luasnip.jumpable(-1) then
-    				luasnip.jump(-1)
-    			else
-    				fallback()
-    			end
-    		end, { "i", "s" }),
-    	}),
-    	formatting = {
-    		fields = { "kind", "abbr", "menu" },
-    		format = function(entry, vim_item)
-    			vim_item.kind = string.format("%s", kind_icons[vim_item.kind])
-    			vim_item.menu = ({
-    				path = "[Path]",
-    				nvim_lua = "[NVIM_LUA]",
-    				nvim_lsp = "[LSP]",
-    				luasnip = "[Snippet]",
-    				buffer = "[Buffer]",
-    			})[entry.source.name]
-    			return vim_item
-    		end,
-    	},
-    	sources = {
-    		{ name = "path" },
-    		{ name = "nvim_lua" },
-    		{ name = "nvim_lsp" },
-    		{ name = "luasnip" },
-    		{ name = "buffer" },
-    	},
-    	confirm_opts = {
-    		behavior = cmp.ConfirmBehavior.Replace,
-    		select = false,
-    	},
-    	window = {
-    		completion = cmp.config.window.bordered(),
-    		documentation = cmp.config.window.bordered(),
-    	},
-    	experimental = {
-    		ghost_text = false,
-    		native_menu = false,
-    	},
-    })
-    cmp.setup.cmdline(":", {
-    	mapping = cmp.mapping.preset.cmdline(),
-    	sources = cmp.config.sources({
-    		{ name = "path" },
-    	}, {
-    		{ name = "cmdline" },
-    	}),
-    })
-
-    -------------------
-    -- About none-ls --
-    -------------------
-    -- format(async)
-    local async_formatting = function(bufnr)
-    	bufnr = bufnr or vim.api.nvim_get_current_buf()
-
-    	vim.lsp.buf_request(
-    		bufnr,
-    		"textDocument/formatting",
-    		vim.lsp.util.make_formatting_params({}),
-    		function(err, res, ctx)
-    			if err then
-    				local err_msg = type(err) == "string" and err or err.message
-    				-- you can modify the log message / level (or ignore it completely)
-    				vim.notify("formatting: " .. err_msg, vim.log.levels.WARN)
-    				return
-    			end
-
-    			-- don't apply results if buffer is unloaded or has been modified
-    			if not vim.api.nvim_buf_is_loaded(bufnr) or vim.api.nvim_buf_get_option(bufnr, "modified") then
-    				return
-    			end
-
-    			if res then
-    				local client = vim.lsp.get_client_by_id(ctx.client_id)
-    				vim.lsp.util.apply_text_edits(res, bufnr, client and client.offset_encoding or "utf-16")
-    				vim.api.nvim_buf_call(bufnr, function()
-    					vim.cmd("silent noautocmd update")
-    				end)
-    			end
-    		end
-    	)
-    end
-    local augroup = vim.api.nvim_create_augroup("LspFormatting", {})
-    local lsp_formatting = function(bufnr)
-    	vim.lsp.buf.format({
-    		filter = function(client)
-    			-- apply whatever logic you want (in this example, we'll only use null-ls)
-    			return client.name == "null-ls"
-    		end,
-    		bufnr = bufnr,
-    	})
-    end
-    require("null-ls").setup({
-    	sources = {
-    		-- you must download code formatter by yourself!
-    		require("null-ls").builtins.formatting.nixpkgs_fmt,
-    	},
-    	debug = false,
-    	on_attach = function(client, bufnr)
-    		if client.supports_method("textDocument/formatting") then
-    			vim.api.nvim_clear_autocmds({ group = augroup, buffer = bufnr })
-    			vim.api.nvim_create_autocmd("BufWritePost", {
-    				group = augroup,
-    				buffer = bufnr,
-    				callback = function()
-    					async_formatting(bufnr)
-    					lsp_formatting(bufnr)
-    				end,
-    			})
-    		end
-    	end,
-    })
-    ---------------------
-    -- About lspconfig --
-    ---------------------
-    local nvim_lsp = require("lspconfig")
-
-    -- Add additional capabilities supported by nvim-cmp
-    -- nvim hasn't added foldingRange to default capabilities, users must add it manually
-    local capabilities = require("cmp_nvim_lsp").default_capabilities()
-    capabilities = vim.lsp.protocol.make_client_capabilities()
-    capabilities.textDocument.foldingRange = {
-    	dynamicRegistration = false,
-    	lineFoldingOnly = true,
-    }
-
-    --Change diagnostic symbols in the sign column (gutter)
-    local signs = { Error = " ", Warn = " ", Hint = " ", Info = " " }
-    for type, icon in pairs(signs) do
-    	local hl = "DiagnosticSign" .. type
-    	vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = hl })
-    end
-    vim.diagnostic.config({
-    	virtual_text = false,
-    	signs = true,
-    	underline = true,
-    	update_in_insert = true,
-    	severity_sort = false,
-    })
-
-    local on_attach = function(bufnr)
-    	vim.api.nvim_create_autocmd("CursorHold", {
-    		buffer = bufnr,
-    		callback = function()
-    			local opts = {
-    				focusable = false,
-    				close_events = { "BufLeave", "CursorMoved", "InsertEnter", "FocusLost" },
-    				border = "rounded",
-    				source = "always",
-    				prefix = " ",
-    				scope = "line",
-    			}
-    			vim.diagnostic.open_float(nil, opts)
-    		end,
-    	})
-    end
-    nvim_lsp.nixd.setup({
-        on_attach = on_attach(),
-        capabilities = capabilities,
-        settings = {
-            nixd = {
-                nixpkgs = {
-                    expr = "import <nixpkgs> { }",
-                },
-                formatting = {
-                    command = { "nixfmt" },
-                },
-                options = {
-                    nixos = {
-                        expr = '(builtins.getFlake "/tmp/NixOS_Home-Manager").nixosConfigurations.hostname.options',
-                    },
-                    home_manager = {
-                        expr = '(builtins.getFlake "/tmp/NixOS_Home-Manager").homeConfigurations."user@hostname".options',
-                    },
-                    flake_parts = {
-                        expr = 'let flake = builtins.getFlake ("/tmp/NixOS_Home-Manager"); in flake.debug.options // flake.currentSystem.options',
-                    },
-                },
+            home_manager = {
+              expr = string.format('(%s).homeConfigurations."user@hostname".options', flake_expr)
             },
+            flake_parts = {
+              expr = string.format('let flake = %s; in flake.debug.options // flake.currentSystem.options', flake_expr)
+            },
+          },
         },
+      },
+    })
+    nvim_lsp.enable("nixd")
+
+    vim.api.nvim_create_autocmd('LspAttach', {
+      callback = function(ev)
+        local opts = { buffer = ev.buf }
+        vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts)
+        vim.keymap.set('n', 'K', vim.lsp.buf.hover, opts)
+        vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
+        vim.keymap.set('n', '<leader>ca', vim.lsp.buf.code_action, opts)
+
+        -- Enable built-in auto-completion and Format on save
+        local client = vim.lsp.get_client_by_id(ev.data.client_id)
+        vim.lsp.completion.enable(true, client.id, ev.buf, { autotrigger = true })
+        vim.api.nvim_create_autocmd('BufWritePre', {
+          buffer = ev.buf,
+          callback = function() vim.lsp.buf.format({ bufnr = ev.buf, id = client.id }) end,
+        })
+      end,
     })
 
-    -------------------
-    -- About lspsaga --
-    -------------------
-    local colors, kind
-    colors = { normal_bg = "#3b4252" }
-    require("lspsaga").setup({
-        ui = {
-            colors = colors,
-            kind = kind,
-            border = "single",
-        },
-        outline = {
-            win_width = 25,
-        },
-    })
-    vim.cmd([[ colorscheme nord ]])
-
-    local keymap = vim.keymap.set
-
-    -- Lsp finder
-    -- Find the symbol definition, implementation, reference.
-    -- If there is no implementation, it will hide.
-    -- When you use action in finder like open, vsplit, then you can use <C-t> to jump back.
-    keymap("n", "gh", "<cmd>Lspsaga lsp_finder<CR>", { silent = true, desc = "Lsp finder" })
-
-    -- Code action
-    keymap("n", "<leader>ca", "<cmd>Lspsaga code_action<CR>", { silent = true, desc = "Code action" })
-    keymap("v", "<leader>ca", "<cmd>Lspsaga code_action<CR>", { silent = true, desc = "Code action" })
-
-    -- Rename
-    keymap("n", "gr", "<cmd>Lspsaga rename<CR>", { silent = true, desc = "Rename" })
-    -- Rename word in whole project
-    keymap("n", "gr", "<cmd>Lspsaga rename ++project<CR>", { silent = true, desc = "Rename in project" })
-
-    -- Peek definition
-    keymap("n", "gD", "<cmd>Lspsaga peek_definition<CR>", { silent = true, desc = "Peek definition" })
-
-    -- Go to definition
-    keymap("n", "gd", "<cmd>Lspsaga goto_definition<CR>", { silent = true, desc = "Go to definition" })
-
-    -- Show line diagnostics
-    keymap("n", "<leader>sl", "<cmd>Lspsaga show_line_diagnostics<CR>", { silent = true, desc = "Show line diagnostics" })
-
-    -- Show cursor diagnostics
-    keymap(
-        "n",
-        "<leader>sc",
-        "<cmd>Lspsaga show_cursor_diagnostics<CR>",
-        { silent = true, desc = "Show cursor diagnostic" }
-    )
-
-    -- Show buffer diagnostics
-    keymap("n", "<leader>sb", "<cmd>Lspsaga show_buf_diagnostics<CR>", { silent = true, desc = "Show buffer diagnostic" })
-
-    -- Diagnostic jump prev
-    keymap("n", "[e", "<cmd>Lspsaga diagnostic_jump_prev<CR>", { silent = true, desc = "Diagnostic jump prev" })
-
-    -- Diagnostic jump next
-    keymap("n", "]e", "<cmd>Lspsaga diagnostic_jump_next<CR>", { silent = true, desc = "Diagnostic jump next" })
-
-    -- Goto prev error
-    keymap("n", "[E", function()
-        require("lspsaga.diagnostic"):goto_prev({ severity = vim.diagnostic.severity.ERROR })
-    end, { silent = true, desc = "Goto prev error" })
-
-    -- Goto next error
-    keymap("n", "]E", function()
-        require("lspsaga.diagnostic"):goto_next({ severity = vim.diagnostic.severity.ERROR })
-    end, { silent = true, desc = "Goto next error" })
-
-    -- Toggle outline
-    keymap("n", "ss", "<cmd>Lspsaga outline<CR>", { silent = true, desc = "Toggle outline" })
-
-    -- Hover doc
-    keymap("n", "K", "<cmd>Lspsaga hover_doc ++keep<CR>", { silent = true, desc = "Hover doc" })
-
-    -- Incoming calls
-    keymap("n", "<Leader>ci", "<cmd>Lspsaga incoming_calls<CR>", { silent = true, desc = "Incoming calls" })
-
-    -- Outgoing calls
-    keymap("n", "<Leader>co", "<cmd>Lspsaga outgoing_calls<CR>", { silent = true, desc = "Outgoing calls" })
-
-    -- Float terminal
-    keymap("n", "<A-d>", "<cmd>Lspsaga term_toggle<CR>", { silent = true, desc = "Float terminal" })
-    keymap("t", "<A-d>", "<cmd>Lspsaga term_toggle<CR>", { silent = true, desc = "Float terminal" })
+    -- Completion Menu UI (Tab to navigate next, Enter to select)
+    vim.keymap.set('i', '<Tab>', function() return vim.fn.pumvisible() == 1 and "<C-n>" or "<Tab>" end, { expr = true })
+    vim.keymap.set('i', '<CR>', function() return vim.fn.pumvisible() == 1 and "<C-y>" or "<CR>" end, { expr = true })
   '';
 in
 pkgs.runCommand "nvim-lsp" { } ''

--- a/nixd/docs/editors/test-shell.nix
+++ b/nixd/docs/editors/test-shell.nix
@@ -1,0 +1,46 @@
+{
+  pkgs,
+  nixd,
+  editor,
+  examplesSrc,
+}:
+let
+  editors = {
+    nvim = {
+      pkg = pkgs.callPackage ./nvim-lsp.nix { };
+      cmd = "nvim-lsp";
+    };
+    vscodium = {
+      pkg = pkgs.callPackage ./vscodium.nix { };
+      cmd = "codium-test";
+    };
+  };
+
+  editorCfg = editors.${editor};
+  editorPkg = editorCfg.pkg;
+  editorCmd = editorCfg.cmd;
+
+  shellHook = ''
+    echo -e "\033[1;31mDuring the first time nixd launches, the flake inputs will be fetched from the internet, this is rather slow.\033[0m"
+    export WORK_ROOT=$(mktemp -d -p /tmp nixd-test-XXXXXX)
+    export WORK_TEMP="$WORK_ROOT/${baseNameOf examplesSrc}"
+
+    mkdir -p "$WORK_TEMP"
+    cp -r ${examplesSrc}/* "$WORK_TEMP/"
+    chmod -R u+w "$WORK_TEMP"
+
+    cd "$WORK_TEMP"
+
+    echo -e "\033[1;32mNow, you can edit the nix file by running the following command:\033[0m"
+    echo -e "\033[1;33m'${editorCmd} .'\033[0m"
+  '';
+in
+pkgs.mkShell {
+  nativeBuildInputs = [
+    nixd
+    pkgs.nixfmt
+    pkgs.git
+    editorPkg
+  ];
+  inherit shellHook;
+}

--- a/nixd/docs/editors/vscodium.nix
+++ b/nixd/docs/editors/vscodium.nix
@@ -12,13 +12,34 @@ let
 in
 writeShellScriptBin "codium-test" ''
   set -e
-  dir="''${XDG_CACHE_HOME:-~/.cache}/nixd-codium"
+  dir="''${XDG_CACHE_HOME:-$HOME/.cache}/nixd-codium"
   ${coreutils}/bin/mkdir -p "$dir/User"
   cat >"$dir/User/settings.json" <<EOF
   {
-  "security.workspace.trust.enabled": false,
-  "nix.enableLanguageServer": true,
-  "nix.serverPath": "nixd",
+    "security.workspace.trust.enabled": false,
+    "nix.enableLanguageServer": true,
+    "nix.serverPath": "nixd",
+    "nix.serverSettings": {
+      "nixd": {
+        "nixpkgs": {
+          "expr": "import (builtins.getFlake (toString ./.)).inputs.nixpkgs { }"
+        },
+        "formatting": {
+          "command": [ "nixfmt" ]
+        },
+        "options": {
+          "nixos": {
+            "expr": "(builtins.getFlake (toString ./.)).nixosConfigurations.hostname.options"
+          },
+          "home_manager": {
+            "expr": "(builtins.getFlake (toString ./.)).homeConfigurations.\"user@hostname\".options"
+          },
+          "flake_parts": {
+            "expr": "let flake = builtins.getFlake (toString ./.); in flake.debug.options // flake.currentSystem.options"
+          }
+        }
+      }
+    }
   }
   EOF
   ${codium}/bin/codium --user-data-dir "$dir" "$@"


### PR DESCRIPTION
- Consolidate editor devShells in flake.nix into a shared test-shell script.
- Copy local examples to /tmp instead of fetching via git.
- Use native Neovim LSP APIs and built-in completion.
- Fix VSCodium cache path and add nixd server settings for example projects.