### PR TITLE
auto-complete default(Text) value for option

### DIFF
--- a/nixd/include/nixd/Protocol/AttrSet.h
+++ b/nixd/include/nixd/Protocol/AttrSet.h
@@ -130,6 +130,7 @@ struct OptionDescription {
   std::vector<lspserver::Location> Declarations;
   std::vector<lspserver::Location> Definitions;
   std::optional<std::string> Example;
+  std::optional<std::string> Default;
   std::optional<OptionType> Type;
 };
 

--- a/nixd/lib/Controller/Completion.cpp
+++ b/nixd/lib/Controller/Completion.cpp
@@ -184,17 +184,16 @@ class OptionCompletionProvider {
   }
 
   void fillInsertText(CompletionItem &Item, const std::string &Name,
-                      const OptionDescription &Desc) const {
+                      const std::string &Value) const {
     if (!ClientSupportSnippet) {
       Item.insertTextFormat = InsertTextFormat::PlainText;
-      Item.insertText = Name + " = " + Desc.Example.value_or("") + ";";
+      Item.insertText = Name + " = " + Value + ";";
       return;
     }
     Item.insertTextFormat = InsertTextFormat::Snippet;
-    Item.insertText =
-        Name + " = " +
-        "${1:" + escapeCharacters({'\\', '$', '}'}, Desc.Example.value_or("")) +
-        "}" + ";";
+    Item.insertText = Name + " = " +
+                      "${1:" + escapeCharacters({'\\', '$', '}'}, Value) + "}" +
+                      ";";
   }
 
 public:
@@ -223,30 +222,81 @@ public:
     Ready.acquire();
     // Now we have "Names", use these to fill "Items".
     for (const nixd::OptionField &Field : Names) {
-      CompletionItem Item;
-
-      Item.label = Field.Name;
-      Item.detail = ModuleOrigin;
-
-      if (Field.Description) {
-        const OptionDescription &Desc = *Field.Description;
-        Item.kind = OptionKind;
-        fillInsertText(Item, Field.Name, Desc);
-        Item.documentation = MarkupContent{
-            .kind = MarkupKind::Markdown,
-            .value = Desc.Description.value_or(""),
-        };
-        Item.detail += " | "; // separater between origin and type desc.
-        if (Desc.Type) {
-          std::string TypeName = Desc.Type->Name.value_or("");
-          std::string TypeDesc = Desc.Type->Description.value_or("");
-          Item.detail += llvm::formatv("{0} ({1})", TypeName, TypeDesc);
-        } else {
-          Item.detail += "? (missing type)";
-        }
-        addItem(Items, std::move(Item));
-      } else {
+      if (!Field.Description) {
+        CompletionItem Item;
+        Item.label = Field.Name;
+        Item.detail = ModuleOrigin;
         Item.kind = OptionAttrKind;
+        addItem(Items, std::move(Item));
+        continue;
+      }
+
+      const OptionDescription &Desc = *Field.Description;
+
+      // Build the shared bits (detail, documentation) once, then emit one
+      // completion item per value source (`example`, `default`). This lets
+      // the user pick between the sample code the option author suggested
+      // and its default value - useful when an option only has one of the
+      // two, or when the user wants the default as a starting point.
+      std::string TypeDetail = ModuleOrigin + " | ";
+      if (Desc.Type) {
+        std::string TypeName = Desc.Type->Name.value_or("");
+        std::string TypeDesc = Desc.Type->Description.value_or("");
+        TypeDetail += llvm::formatv("{0} ({1})", TypeName, TypeDesc);
+      } else {
+        TypeDetail += "? (missing type)";
+      }
+      MarkupContent Doc{
+          .kind = MarkupKind::Markdown,
+          .value = Desc.Description.value_or(""),
+      };
+
+      // Check whether both variants will be emitted so we can decide
+      // whether to disambiguate the labels with "(example)" / "(default)".
+      bool HasExample = Desc.Example.has_value();
+      // Only emit a separate `default` item when it would differ from the
+      // example; otherwise the user would see two identical snippets.
+      bool HasDefault =
+          Desc.Default.has_value() && Desc.Default != Desc.Example;
+      bool HasBoth = HasExample && HasDefault;
+
+      auto emit = [&](const std::string &Value, llvm::StringRef Source,
+                      llvm::StringRef SortPrefix) {
+        CompletionItem Item;
+        // When both variants exist, append the source so users can tell
+        // them apart. `filterText` is always the plain option name so
+        // typing the name matches both items.
+        if (HasBoth)
+          Item.label = llvm::formatv("{0} ({1})", Field.Name, Source);
+        else
+          Item.label = Field.Name;
+        Item.filterText = Field.Name;
+        Item.sortText = (SortPrefix + Field.Name).str();
+        Item.kind = OptionKind;
+        Item.detail = TypeDetail;
+        Item.documentation = Doc;
+        fillInsertText(Item, Field.Name, Value);
+        addItem(Items, std::move(Item));
+      };
+
+      bool Emitted = false;
+      if (HasExample) {
+        emit(*Desc.Example, "example", "0");
+        Emitted = true;
+      }
+      if (HasDefault) {
+        emit(*Desc.Default, "default", "1");
+        Emitted = true;
+      }
+      if (!Emitted) {
+        // No example or default to insert — still offer the option name
+        // as a bare completion so users can discover it.
+        CompletionItem Item;
+        Item.label = Field.Name;
+        Item.kind = OptionKind;
+        Item.detail = TypeDetail;
+        Item.documentation = Doc;
+        fillInsertText(Item, Field.Name, "");
         addItem(Items, std::move(Item));
       }
     }

--- a/nixd/lib/Eval/AttrSetProvider.cpp
+++ b/nixd/lib/Eval/AttrSetProvider.cpp
@@ -130,6 +130,46 @@ void fillOptionType(nix::EvalState &State, nix::Value &VType, OptionType &R) {
   fillString(State, VType, {"name"}, R.Name);
 }
 
+/// Render an option's `example` or `default` field as a string suitable for
+/// code completion. Handles `literalExpression` wrappers as used in nixpkgs.
+/// When \p AllowComplex is false, only scalar values (strings, numbers,
+/// booleans, null, paths) are rendered; attrsets, lists, lambdas, and thunks
+/// are skipped to avoid infinite recursion.
+std::optional<std::string> renderOptionValue(nix::EvalState &State,
+                                             nix::Value &V, bool AllowComplex) {
+  try {
+    State.forceValue(V, nix::noPos);
+
+    // In nixpkgs these fields are often wrapped in `literalExpression`
+    // which carries the source text.
+    if (nixt::checkField(State, V, "_type", "literalExpression")) {
+      if (auto Text = nixt::getFieldString(State, V, "text"))
+        return std::string(*Text);
+      return std::nullopt;
+    }
+
+    if (!AllowComplex) {
+      switch (V.type()) {
+      case nix::ValueType::nString:
+      case nix::ValueType::nInt:
+      case nix::ValueType::nFloat:
+      case nix::ValueType::nBool:
+      case nix::ValueType::nNull:
+      case nix::ValueType::nPath:
+        break;
+      default:
+        return std::nullopt;
+      }
+    }
+
+    std::ostringstream OS;
+    V.print(State, OS);
+    return OS.str();
+  } catch (std::exception &) {
+    return std::nullopt;
+  }
+}
+
 void fillOptionDescription(nix::EvalState &State, nix::Value &V,
                            OptionDescription &R) {
   fillString(State, V, {"description"}, R.Description);
@@ -144,16 +184,20 @@ void fillOptionDescription(nix::EvalState &State, nix::Value &V,
     }
 
     if (auto *It = V.attrs()->get(State.symbols.create("example"))) {
-      State.forceValue(*It->value, It->pos);
+      R.Example = renderOptionValue(State, *It->value, /*AllowComplex=*/true);
+    }
 
-      // In nixpkgs some examples are nested in "literalExpression"
-      if (nixt::checkField(State, *It->value, "_type", "literalExpression")) {
-        R.Example = nixt::getFieldString(State, *It->value, "text");
-      } else {
-        std::ostringstream OS;
-        It->value->print(State, OS);
-        R.Example = OS.str();
-      }
+    // Fall back to the option's default so completion still has something
+    // useful to offer when no `example` is provided. `defaultText` takes
+    // priority over `default`: nixpkgs authors set `defaultText` precisely
+    // when the raw `default` would be unhelpful (e.g. a self-referential
+    // attrset or lambda), so its presence alone means `default` should be
+    // ignored — falling back would defeat the author's intent. Complex
+    // raw defaults are also refused to avoid infinite recursion.
+    if (auto *It = V.attrs()->get(State.symbols.create("defaultText"))) {
+      R.Default = renderOptionValue(State, *It->value, /*AllowComplex=*/false);
+    } else if (auto *It = V.attrs()->get(State.symbols.create("default"))) {
+      R.Default = renderOptionValue(State, *It->value, /*AllowComplex=*/false);
     }
   }
 }

--- a/nixd/lib/Protocol/AttrSet.cpp
+++ b/nixd/lib/Protocol/AttrSet.cpp
@@ -23,6 +23,7 @@ Value nixd::toJSON(const OptionDescription &Params) {
       {"Declarations", Params.Declarations},
       {"Definitions", Params.Definitions},
       {"Example", Params.Example},
+      {"Default", Params.Default},
       {"Type", Params.Type},
   };
 }
@@ -33,6 +34,7 @@ bool nixd::fromJSON(const Value &Params, OptionDescription &R, Path P) {
          && O.mapOptional("Declarations", R.Declarations) //
          && O.mapOptional("Definitions", R.Definitions)   //
          && O.mapOptional("Example", R.Example)           //
+         && O.mapOptional("Default", R.Default)           //
          && O.mapOptional("Type", R.Type)                 //
       ;
 }

--- a/nixd/tools/nixd-attrset-eval/test/option-info.md
+++ b/nixd/tools/nixd-attrset-eval/test/option-info.md
@@ -16,6 +16,47 @@
       { column = 16; file = "/nix/store/43fgdg04gbrjh8ww8q8zgbqxn4sb35py-source/lib/attrsets.nix"; line = 190; }
     ];
   };
+  boot.kernelModules = {
+    _type = "option";
+    description = "The set of kernel modules to be loaded in the second stage of the boot process.";
+    type = {
+      description = "list of string";
+      name = "listOf";
+    };
+    default = [ ];
+    example = {
+      _type = "literalExpression";
+      text = "[ \"kvm-intel\" \"snd_hda_intel\" ]";
+    };
+    declarationPositions = [ ];
+  };
+  boot.kernelPackages = {
+    _type = "option";
+    description = "The kernel packages set.";
+    type = {
+      description = "unspecified value";
+      name = "unspecified";
+    };
+    # `defaultText` must take priority over the raw `default` below:
+    # nixpkgs sets `defaultText` precisely because the real default
+    # does not render to anything a user could paste back.
+    default = "placeholder";
+    defaultText = {
+      _type = "literalExpression";
+      text = "pkgs.linuxPackages";
+    };
+    declarationPositions = [ ];
+  };
+  boot.tmp.cleanOnBoot = {
+    _type = "option";
+    description = "Whether to clean `/tmp` on boot.";
+    type = {
+      description = "boolean";
+      name = "bool";
+    };
+    default = false;
+    declarationPositions = [ ];
+  };
 }
 ```
 
@@ -24,9 +65,11 @@
    "jsonrpc":"2.0",
    "id":0,
    "method":"attrset/evalExpr",
-   "params": "{\r\n  boot.bcache.bar = 1;\r\n  boot.binfmt.bar = 1;\r\n  boot.binfmtMiscRegistrations = {\r\n    _type = \"option\";\r\n    description = \"Alias of {option}`boot.binfmt.registrations`.\";\r\n    type = {\r\n      description = \"attribute set of (submodule)\";\r\n      name = \"attrsOf\";\r\n    };\r\n    declarationPositions = [\r\n      { column = 16; file = \"\/nix\/store\/43fgdg04gbrjh8ww8q8zgbqxn4sb35py-source\/lib\/attrsets.nix\"; line = 190; }\r\n    ];\r\n  };\r\n}"
+   "params": "{\r\n  boot.bcache.bar = 1;\r\n  boot.binfmt.bar = 1;\r\n  boot.binfmtMiscRegistrations = {\r\n    _type = \"option\";\r\n    description = \"Alias of {option}`boot.binfmt.registrations`.\";\r\n    type = {\r\n      description = \"attribute set of (submodule)\";\r\n      name = \"attrsOf\";\r\n    };\r\n    declarationPositions = [\r\n      { column = 16; file = \"\/nix\/store\/43fgdg04gbrjh8ww8q8zgbqxn4sb35py-source\/lib\/attrsets.nix\"; line = 190; }\r\n    ];\r\n  };\r\n  boot.kernelModules = {\r\n    _type = \"option\";\r\n    description = \"The set of kernel modules to be loaded in the second stage of the boot process.\";\r\n    type = {\r\n      description = \"list of string\";\r\n      name = \"listOf\";\r\n    };\r\n    default = [ ];\r\n    example = {\r\n      _type = \"literalExpression\";\r\n      text = \"[ \\\"kvm-intel\\\" \\\"snd_hda_intel\\\" ]\";\r\n    };\r\n    declarationPositions = [ ];\r\n  };\r\n  boot.kernelPackages = {\r\n    _type = \"option\";\r\n    description = \"The kernel packages set.\";\r\n    type = {\r\n      description = \"unspecified value\";\r\n      name = \"unspecified\";\r\n    };\r\n    default = \"placeholder\";\r\n    defaultText = {\r\n      _type = \"literalExpression\";\r\n      text = \"pkgs.linuxPackages\";\r\n    };\r\n    declarationPositions = [ ];\r\n  };\r\n  boot.tmp.cleanOnBoot = {\r\n    _type = \"option\";\r\n    description = \"Whether to clean `\/tmp` on boot.\";\r\n    type = {\r\n      description = \"boolean\";\r\n      name = \"bool\";\r\n    };\r\n    default = false;\r\n    declarationPositions = [ ];\r\n  };\r\n}"
 }
 ```
+
+An option that has neither `default` nor `example` reports null for both fields.
 
 ```json
 {
@@ -37,11 +80,73 @@
 }
 ```
 ```
-CHECK:          "Description": "Alias of {option}`boot.binfmt.registrations`.",
+CHECK:          "Default": null,
+CHECK-NEXT:     "Definitions": [],
+CHECK-NEXT:     "Description": "Alias of {option}`boot.binfmt.registrations`.",
 CHECK-NEXT:     "Example": null,
 CHECK-NEXT:     "Type": {
 CHECK-NEXT:        "Description": "attribute set of (submodule)",
 CHECK-NEXT:        "Name": "attrsOf"
+CHECK-NEXT:     }
+```
+
+An option with a complex `default` but a `literalExpression` `example` reports
+only the example; a raw list default is rejected to avoid deep recursion.
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"attrset/optionInfo",
+   "params": [ "boot", "kernelModules" ]
+}
+```
+```
+CHECK:          "Default": null,
+CHECK-NEXT:     "Definitions": [],
+CHECK-NEXT:     "Description": "The set of kernel modules to be loaded in the second stage of the boot process.",
+CHECK-NEXT:     "Example": "[ \"kvm-intel\" \"snd_hda_intel\" ]",
+CHECK-NEXT:     "Type": {
+```
+
+An option with both `default` and `defaultText` uses `defaultText`: the
+author set `defaultText` precisely because the raw `default` would be
+unhelpful, so it must win (otherwise we would report `"placeholder"`).
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":3,
+   "method":"attrset/optionInfo",
+   "params": [ "boot", "kernelPackages" ]
+}
+```
+```
+CHECK:          "Default": "pkgs.linuxPackages",
+CHECK-NEXT:     "Definitions": [],
+CHECK-NEXT:     "Description": "The kernel packages set.",
+CHECK-NEXT:     "Example": null,
+CHECK-NEXT:     "Type": {
+```
+
+An option with a scalar `default` and no `example` falls back to the default.
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":4,
+   "method":"attrset/optionInfo",
+   "params": [ "boot", "tmp", "cleanOnBoot" ]
+}
+```
+```
+CHECK:          "Default": "false",
+CHECK-NEXT:     "Definitions": [],
+CHECK-NEXT:     "Description": "Whether to clean `/tmp` on boot.",
+CHECK-NEXT:     "Example": null,
+CHECK-NEXT:     "Type": {
+CHECK-NEXT:        "Description": "boolean",
+CHECK-NEXT:        "Name": "bool"
 CHECK-NEXT:     }
 ```
 

--- a/nixd/tools/nixd/test/completion/options-default-only.md
+++ b/nixd/tools/nixd/test/completion/options-default-only.md
@@ -1,0 +1,85 @@
+# RUN: nixd --lit-test \
+# RUN: --nixos-options-expr="{ foo.bar = { _type = \"option\"; type = { name = \"bool\"; description = \"boolean\"; }; defaultText = { _type = \"literalExpression\"; text = \"pkgs.stdenv.hostPlatform.isLinux\"; }; }; }" \
+# RUN: < %s | FileCheck %s
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities": {
+        "textDocument": {
+          "completion": {
+            "completionItem": {
+              "snippetSupport": true
+            }
+          }
+        }
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+
+```nix file:///completion.nix
+{ bar = 1; foo.ba }
+```
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "textDocument/completion",
+    "params": {
+        "textDocument": {
+            "uri": "file:///completion.nix"
+        },
+        "position": {
+            "line": 0,
+            "character": 16
+        },
+        "context": {
+            "triggerKind": 1
+        }
+    }
+}
+```
+
+When an option has only a `defaultText` (no `example`), the completion
+label should be the plain option name without any `(default)` suffix.
+
+```
+     CHECK: "id": 1,
+CHECK-NEXT: "jsonrpc": "2.0",
+CHECK-NEXT: "result": {
+CHECK-NEXT:   "isIncomplete": false,
+CHECK-NEXT:   "items": [
+CHECK-NEXT:     {
+CHECK-NEXT:       "data": "",
+CHECK-NEXT:       "detail": "nixos | bool (boolean)",
+CHECK-NEXT:       "documentation": null,
+CHECK-NEXT:       "filterText": "bar",
+CHECK-NEXT:       "insertText": "bar = ${1:pkgs.stdenv.hostPlatform.isLinux};",
+CHECK-NEXT:       "insertTextFormat": 2,
+CHECK-NEXT:       "kind": 4,
+CHECK-NEXT:       "label": "bar",
+CHECK-NEXT:       "score": 0,
+CHECK-NEXT:       "sortText": "1bar"
+CHECK-NEXT:     }
+CHECK-NEXT:   ]
+CHECK-NEXT: }
+```
+
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/completion/options-default.md
+++ b/nixd/tools/nixd/test/completion/options-default.md
@@ -1,0 +1,100 @@
+# RUN: nixd --lit-test \
+# RUN: --nixos-options-expr="{ foo.bar = { _type = \"option\"; type = { name = \"bool\"; description = \"boolean\"; }; example = { _type = \"literalExpression\"; text = \"true\"; }; defaultText = { _type = \"literalExpression\"; text = \"pkgs.stdenv.hostPlatform.isLinux\"; }; }; }" \
+# RUN: < %s | FileCheck %s
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities": {
+        "textDocument": {
+          "completion": {
+            "completionItem": {
+              "snippetSupport": true
+            }
+          }
+        }
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+
+```nix file:///completion.nix
+{ bar = 1; foo.ba }
+```
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "textDocument/completion",
+    "params": {
+        "textDocument": {
+            "uri": "file:///completion.nix"
+        },
+        "position": {
+            "line": 0,
+            "character": 16
+        },
+        "context": {
+            "triggerKind": 1
+        }
+    }
+}
+```
+
+An option with both `example` and `defaultText` (both wrapped in
+`literalExpression`, as is conventional in nixpkgs) is offered as two
+completion items so the user can pick which value to insert. The
+`example` variant sorts first (sortText prefix "0") and the `default`
+variant second ("1").
+
+```
+     CHECK: "id": 1,
+CHECK-NEXT: "jsonrpc": "2.0",
+CHECK-NEXT: "result": {
+CHECK-NEXT:   "isIncomplete": false,
+CHECK-NEXT:   "items": [
+CHECK-NEXT:     {
+CHECK-NEXT:       "data": "",
+CHECK-NEXT:       "detail": "nixos | bool (boolean)",
+CHECK-NEXT:       "documentation": null,
+CHECK-NEXT:       "filterText": "bar",
+CHECK-NEXT:       "insertText": "bar = ${1:true};",
+CHECK-NEXT:       "insertTextFormat": 2,
+CHECK-NEXT:       "kind": 4,
+CHECK-NEXT:       "label": "bar (example)",
+CHECK-NEXT:       "score": 0,
+CHECK-NEXT:       "sortText": "0bar"
+CHECK-NEXT:     },
+CHECK-NEXT:     {
+CHECK-NEXT:       "data": "",
+CHECK-NEXT:       "detail": "nixos | bool (boolean)",
+CHECK-NEXT:       "documentation": null,
+CHECK-NEXT:       "filterText": "bar",
+CHECK-NEXT:       "insertText": "bar = ${1:pkgs.stdenv.hostPlatform.isLinux};",
+CHECK-NEXT:       "insertTextFormat": 2,
+CHECK-NEXT:       "kind": 4,
+CHECK-NEXT:       "label": "bar (default)",
+CHECK-NEXT:       "score": 0,
+CHECK-NEXT:       "sortText": "1bar"
+CHECK-NEXT:     }
+CHECK-NEXT:   ]
+CHECK-NEXT: }
+```
+
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```


### PR DESCRIPTION
next to `example`, adds an auto-complete option from:

1. `defaultText`, if available
1. `default`, as fall-back

closes #512.

disclaimer i used a coding agent in the creation of this patch.
