### PR TITLE
update nix to 2.34

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772963539,
-        "narHash": "sha256-G4+9cEu8XSqEWYUB6iRgDfrg53av6yyRwAKhSeKbUVw=",
-        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "lastModified": 1776877367,
+        "narHash": "sha256-wMN1gM00sUQ2KC9CNr/XEOGdfOrl67PabIRv9AYayTo=",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre960399.9dcb002ca169/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre985613.0726a0ecb6d4/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
             callPackage
             stdenv
             ;
-          nixComponents = nixVersions.nixComponents_2_33;
+          nixComponents = nixVersions.nixComponents_2_34;
           llvmPackages = llvmPackages_21;
           nixf = callPackage ./libnixf { inherit (nixComponents) nix-expr; };
           nixt = callPackage ./libnixt { inherit nixComponents; };

--- a/nixd/lib/Eval/AttrSetProvider.cpp
+++ b/nixd/lib/Eval/AttrSetProvider.cpp
@@ -66,7 +66,7 @@ std::optional<Location> locationOf(nix::PosTable &PTable, nix::Value &V) {
 
 ValueMeta metadataOf(nix::EvalState &State, nix::Value &V) {
   return {
-      .Type = V.type(true),
+      .Type = V.type<true>(),
       .Location = locationOf(State.positions, V),
   };
 }

--- a/nixd/tools/nixd-attrset-eval/test/attr-info-doc-no-comment.md
+++ b/nixd/tools/nixd-attrset-eval/test/attr-info-doc-no-comment.md
@@ -26,7 +26,7 @@ CHECK-NEXT: "jsonrpc": "2.0",
 CHECK-NEXT: "result": {
 CHECK-NEXT:   "Meta": {
 CHECK-NEXT:     "Location": null,
-CHECK-NEXT:     "Type": 9
+CHECK-NEXT:     "Type": 10
 CHECK-NEXT:   },
 CHECK-NEXT:   "PackageDesc": {
 CHECK-NEXT:     "Description": null,

--- a/nixd/tools/nixd-attrset-eval/test/attrs-info-doc.md
+++ b/nixd/tools/nixd-attrset-eval/test/attrs-info-doc.md
@@ -26,7 +26,7 @@ CHECK-NEXT: "jsonrpc": "2.0",
 CHECK-NEXT: "result": {
 CHECK-NEXT:   "Meta": {
 CHECK-NEXT:     "Location": null,
-CHECK-NEXT:     "Type": 9
+CHECK-NEXT:     "Type": 10
 CHECK-NEXT:   },
 CHECK-NEXT:   "PackageDesc": {
 CHECK-NEXT:     "Description": null,

--- a/nixd/tools/nixd-attrset-eval/test/attrs-info.md
+++ b/nixd/tools/nixd-attrset-eval/test/attrs-info.md
@@ -26,7 +26,7 @@ CHECK-NEXT:  "jsonrpc": "2.0",
 CHECK-NEXT:  "result": {
 CHECK-NEXT:    "Meta": {
 CHECK-NEXT:      "Location": null,
-CHECK-NEXT:      "Type": 7
+CHECK-NEXT:      "Type": 8
 CHECK-NEXT:    },
 CHECK-NEXT:    "PackageDesc": {
 CHECK-NEXT:      "Description": "A program that produces a familiar, friendly greeting",


### PR DESCRIPTION
This required updating to `nixComponents_2_34`, which required changing a function argument to a template argument (changed in nixos/nix@a81f83604b1b487c1f8763aa1c949f95a370d47a).

Some tests also had to be adjusted after nixos/nix@c33d9e31cc3a2f71346e7b587c04a8c8619d546a introduced a new InternalType.

Fixes #799.