### PR TITLE
feat(completion): textEdit support

### DIFF
--- a/nixd/lib/Controller/Completion.cpp
+++ b/nixd/lib/Controller/Completion.cpp
@@ -7,6 +7,7 @@
 #include "CheckReturn.h"
 #include "Convert.h"
 
+#include "lspserver/Logger.h"
 #include "lspserver/Protocol.h"
 
 #include "nixd/Controller/Controller.h"
@@ -141,7 +142,8 @@ public:
   }
 
   /// \brief Ask nixpkgs provider, give us a list of names. (thunks)
-  void completePackages(const AttrPathCompleteParams &Params,
+  void completePackages(const lspserver::Range EditRange,
+                        const AttrPathCompleteParams &Params,
                         std::vector<CompletionItem> &Items) {
     std::binary_semaphore Ready(0);
     std::vector<std::string> Names;
@@ -161,11 +163,18 @@ public:
     // Now we have "Names", use these to fill "Items".
     for (const auto &Name : Names) {
       if (Name.starts_with(Params.Prefix)) {
-        addItem(Items, CompletionItem{
-                           .label = Name,
-                           .kind = CompletionItemKind::Field,
-                           .data = llvm::formatv("{0}", toJSON(Params)),
-                       });
+        CompletionItem Item;
+        Item.label = Name;
+        Item.kind = CompletionItemKind::Field;
+        Item.data = llvm::formatv("{0}", toJSON(Params));
+
+        lspserver::TextEdit Edit;
+        Edit.range = EditRange;
+        Edit.newText = Item.label;
+
+        Item.textEdit = Edit;
+
+        addItem(Items, Item);
       }
     }
   }
@@ -216,7 +225,8 @@ public:
       : OptionClient(OptionClient), ModuleOrigin(std::move(ModuleOrigin)),
         ClientSupportSnippet(ClientSupportSnippet) {}
 
-  void completeOptions(std::vector<std::string> Scope, std::string Prefix,
+  void completeOptions(const lspserver::Range EditRange,
+                       std::vector<std::string> Scope, std::string Prefix,
                        std::vector<CompletionItem> &Items) {
     std::binary_semaphore Ready(0);
     OptionCompleteResponse Names;
@@ -241,6 +251,17 @@ public:
         Item.label = Field.Name;
         Item.detail = ModuleOrigin;
         Item.kind = OptionAttrKind;
+
+        // If prefix is empty there isn't anything to replace and the EditRange
+        // is probably wrong So only perform a textEdit if there is a Prefix
+        if (Params.Prefix != "") {
+          lspserver::TextEdit Edit;
+          Edit.range = EditRange;
+          Edit.newText = Item.label;
+
+          Item.textEdit = Edit;
+        }
+
         addItem(Items, std::move(Item));
         continue;
       }
@@ -289,7 +310,22 @@ public:
         Item.kind = OptionKind;
         Item.detail = TypeDetail;
         Item.documentation = Doc;
+
+        // If prefix is empty there isn't anything to replace and the EditRange
+        // is probably wrong So only perform a textEdit if there is a Prefix
+
         fillInsertText(Item, Field.Name, Value);
+
+        // If prefix is empty there isn't anything to replace and the EditRange
+        // is probably wrong So only perform a textEdit if there is a Prefix
+        if (Params.Prefix != "") {
+          lspserver::TextEdit Edit;
+          Edit.range = EditRange;
+          Edit.newText = Item.insertText;
+
+          Item.textEdit = Edit;
+        }
+
         addItem(Items, std::move(Item));
       };
 
@@ -310,14 +346,27 @@ public:
         Item.kind = OptionKind;
         Item.detail = TypeDetail;
         Item.documentation = Doc;
+
         fillInsertText(Item, Field.Name, "");
+
+        // If prefix is empty there isn't anything to replace and the EditRange
+        // is probably wrong So only perform a textEdit if there is a Prefix
+        if (Params.Prefix != "") {
+          lspserver::TextEdit Edit;
+          Edit.range = EditRange;
+          Edit.newText = Item.insertText;
+
+          Item.textEdit = Edit;
+        }
+
         addItem(Items, std::move(Item));
       }
     }
   }
 };
 
-void completeAttrName(const std::vector<std::string> &Scope,
+void completeAttrName(const lspserver::Range EditRange,
+                      const std::vector<std::string> &Scope,
                       const std::string &Prefix,
                       Controller::OptionMapTy &Options, bool CompletionSnippets,
                       std::vector<CompletionItem> &List) {
@@ -328,13 +377,13 @@ void completeAttrName(const std::vector<std::string> &Scope,
       continue;
     }
     OptionCompletionProvider OCP(*Client, Name, CompletionSnippets);
-    OCP.completeOptions(Scope, Prefix, List);
+    OCP.completeOptions(EditRange, Scope, Prefix, List);
   }
 }
 
-void completeAttrPath(const Node &N, const ParentMapAnalysis &PM,
-                      std::mutex &OptionsLock, Controller::OptionMapTy &Options,
-                      bool Snippets,
+void completeAttrPath(const lspserver::Range EditRange, const Node &N,
+                      const ParentMapAnalysis &PM, std::mutex &OptionsLock,
+                      Controller::OptionMapTy &Options, bool Snippets,
                       std::vector<lspserver::CompletionItem> &Items) {
   std::vector<std::string> Scope;
   using PathResult = FindAttrPathResult;
@@ -345,7 +394,7 @@ void completeAttrPath(const Node &N, const ParentMapAnalysis &PM,
     Scope.pop_back();
     {
       std::lock_guard _(OptionsLock);
-      completeAttrName(Scope, Prefix, Options, Snippets, Items);
+      completeAttrName(EditRange, Scope, Prefix, Options, Snippets, Items);
     }
   }
 }
@@ -367,7 +416,8 @@ AttrPathCompleteParams mkParams(nixd::Selector Sel, bool IsComplete) {
 
 #define DBG DBGPREFIX ": "
 
-void completeVarName(const VariableLookupAnalysis &VLA,
+void completeVarName(const lspserver::Range EditRange,
+                     const VariableLookupAnalysis &VLA,
                      const ParentMapAnalysis &PM, const nixf::ExprVar &N,
                      AttrSetClient &Client, std::vector<CompletionItem> &List) {
 #define DBGPREFIX "completion/var"
@@ -386,7 +436,7 @@ void completeVarName(const VariableLookupAnalysis &VLA,
     // Invoke nixpkgs provider to get the completion list.
     NixpkgsCompletionProvider NCP(Client);
     // Variable names are always incomplete.
-    NCP.completePackages(mkParams(Sel, /*IsComplete=*/false), List);
+    NCP.completePackages(EditRange, mkParams(Sel, /*IsComplete=*/false), List);
   } catch (ExceedSizeError &) {
     // Let "onCompletion" catch this exception to set "inComplete" field.
     throw;
@@ -403,7 +453,8 @@ void completeVarName(const VariableLookupAnalysis &VLA,
 /// e.g.
 ///      - incomplete: `lib.gen|`
 ///      - complete:   `lib.attrset.|`
-void completeSelect(const nixf::ExprSelect &Select, AttrSetClient &Client,
+void completeSelect(const lspserver::Range EditRange,
+                    const nixf::ExprSelect &Select, AttrSetClient &Client,
                     const nixf::VariableLookupAnalysis &VLA,
                     const nixf::ParentMapAnalysis &PM, bool IsComplete,
                     std::vector<CompletionItem> &List) {
@@ -425,7 +476,7 @@ void completeSelect(const nixf::ExprSelect &Select, AttrSetClient &Client,
   try {
     Selector Sel =
         idioms::mkSelector(Select, idioms::mkVarSelector(Var, VLA, PM));
-    NCP.completePackages(mkParams(Sel, IsComplete), List);
+    NCP.completePackages(EditRange, mkParams(Sel, IsComplete), List);
   } catch (ExceedSizeError &) {
     // Let "onCompletion" catch this exception to set "inComplete" field.
     throw;
@@ -455,6 +506,12 @@ void Controller::onCompletion(const CompletionParams &Params,
       const auto &PM = *TU->parentMap();
       const auto &UpExpr = *CheckDefault(PM.upExpr(N));
 
+      lspserver::Range EditRange = toLSPRange(TU->src(), N.range());
+      if (N.kind() == Node::NK_Dot) {
+        // If the node is a dot, insert after the dot
+        EditRange.start = EditRange.end;
+      }
+
       return [&]() {
         CompletionList List;
         const VariableLookupAnalysis &VLA = *TU->variableLookup();
@@ -462,7 +519,8 @@ void Controller::onCompletion(const CompletionParams &Params,
           switch (UpExpr.kind()) {
           // In these cases, assume the cursor have "variable" scoping.
           case Node::NK_ExprVar: {
-            completeVarName(VLA, PM, static_cast<const nixf::ExprVar &>(UpExpr),
+            completeVarName(EditRange, VLA, PM,
+                            static_cast<const nixf::ExprVar &>(UpExpr),
                             *nixpkgsClient(), List.items);
             return List;
           }
@@ -472,12 +530,12 @@ void Controller::onCompletion(const CompletionParams &Params,
           // foo.a.bar|
           case Node::NK_ExprSelect: {
             const auto &Select = static_cast<const nixf::ExprSelect &>(UpExpr);
-            completeSelect(Select, *nixpkgsClient(), VLA, PM,
+            completeSelect(EditRange, Select, *nixpkgsClient(), VLA, PM,
                            N.kind() == Node::NK_Dot, List.items);
             return List;
           }
           case Node::NK_ExprAttrs: {
-            completeAttrPath(N, PM, OptionsLock, Options,
+            completeAttrPath(EditRange, N, PM, OptionsLock, Options,
                              ClientCaps.CompletionSnippets, List.items);
             return List;
           }

--- a/nixd/lib/Controller/Completion.cpp
+++ b/nixd/lib/Controller/Completion.cpp
@@ -7,7 +7,6 @@
 #include "CheckReturn.h"
 #include "Convert.h"
 
-#include "lspserver/Logger.h"
 #include "lspserver/Protocol.h"
 
 #include "nixd/Controller/Controller.h"
@@ -163,18 +162,13 @@ public:
     // Now we have "Names", use these to fill "Items".
     for (const auto &Name : Names) {
       if (Name.starts_with(Params.Prefix)) {
-        CompletionItem Item;
-        Item.label = Name;
-        Item.kind = CompletionItemKind::Field;
-        Item.data = llvm::formatv("{0}", toJSON(Params));
-
-        lspserver::TextEdit Edit;
-        Edit.range = EditRange;
-        Edit.newText = Item.label;
-
-        Item.textEdit = Edit;
-
-        addItem(Items, Item);
+        addItem(Items, CompletionItem{
+                           .label = Name,
+                           .kind = CompletionItemKind::Field,
+                           .textEdit = lspserver::TextEdit{.range = EditRange,
+                                                           .newText = Name},
+                           .data = llvm::formatv("{0}", toJSON(Params)),
+                       });
       }
     }
   }
@@ -245,24 +239,25 @@ public:
     OptionClient.optionComplete(Params, std::move(OnReply));
     Ready.acquire();
     // Now we have "Names", use these to fill "Items".
+    //
+    // When Params.Prefix is empty, the cursor is inside an empty hole and
+    // EditRange does not point at a real prefix to replace, so we omit the
+    // textEdit and let the editor fall back to insertText/label.
+    bool HasPrefix = !Params.Prefix.empty();
+    auto MkTextEdit =
+        [&](llvm::StringRef NewText) -> std::optional<lspserver::TextEdit> {
+      if (!HasPrefix)
+        return std::nullopt;
+      return lspserver::TextEdit{.range = EditRange, .newText = NewText.str()};
+    };
     for (const nixd::OptionField &Field : Names) {
       if (!Field.Description) {
-        CompletionItem Item;
-        Item.label = Field.Name;
-        Item.detail = ModuleOrigin;
-        Item.kind = OptionAttrKind;
-
-        // If prefix is empty there isn't anything to replace and the EditRange
-        // is probably wrong So only perform a textEdit if there is a Prefix
-        if (Params.Prefix != "") {
-          lspserver::TextEdit Edit;
-          Edit.range = EditRange;
-          Edit.newText = Item.label;
-
-          Item.textEdit = Edit;
-        }
-
-        addItem(Items, std::move(Item));
+        addItem(Items, CompletionItem{
+                           .label = Field.Name,
+                           .kind = OptionAttrKind,
+                           .detail = ModuleOrigin,
+                           .textEdit = MkTextEdit(Field.Name),
+                       });
         continue;
       }
 
@@ -297,35 +292,22 @@ public:
 
       auto emit = [&](const std::string &Value, llvm::StringRef Source,
                       llvm::StringRef SortPrefix) {
-        CompletionItem Item;
         // When both variants exist, append the source so users can tell
         // them apart. `filterText` is always the plain option name so
         // typing the name matches both items.
-        if (HasBoth)
-          Item.label = llvm::formatv("{0} ({1})", Field.Name, Source);
-        else
-          Item.label = Field.Name;
-        Item.filterText = Field.Name;
-        Item.sortText = (SortPrefix + Field.Name).str();
-        Item.kind = OptionKind;
-        Item.detail = TypeDetail;
-        Item.documentation = Doc;
-
-        // If prefix is empty there isn't anything to replace and the EditRange
-        // is probably wrong So only perform a textEdit if there is a Prefix
-
+        std::string Label =
+            HasBoth ? llvm::formatv("{0} ({1})", Field.Name, Source).str()
+                    : Field.Name;
+        CompletionItem Item{
+            .label = std::move(Label),
+            .kind = OptionKind,
+            .detail = TypeDetail,
+            .documentation = Doc,
+            .sortText = (SortPrefix + Field.Name).str(),
+            .filterText = Field.Name,
+        };
         fillInsertText(Item, Field.Name, Value);
-
-        // If prefix is empty there isn't anything to replace and the EditRange
-        // is probably wrong So only perform a textEdit if there is a Prefix
-        if (Params.Prefix != "") {
-          lspserver::TextEdit Edit;
-          Edit.range = EditRange;
-          Edit.newText = Item.insertText;
-
-          Item.textEdit = Edit;
-        }
-
+        Item.textEdit = MkTextEdit(Item.insertText);
         addItem(Items, std::move(Item));
       };
 
@@ -341,24 +323,14 @@ public:
       if (!Emitted) {
         // No example or default to insert — still offer the option name
         // as a bare completion so users can discover it.
-        CompletionItem Item;
-        Item.label = Field.Name;
-        Item.kind = OptionKind;
-        Item.detail = TypeDetail;
-        Item.documentation = Doc;
-
+        CompletionItem Item{
+            .label = Field.Name,
+            .kind = OptionKind,
+            .detail = TypeDetail,
+            .documentation = Doc,
+        };
         fillInsertText(Item, Field.Name, "");
-
-        // If prefix is empty there isn't anything to replace and the EditRange
-        // is probably wrong So only perform a textEdit if there is a Prefix
-        if (Params.Prefix != "") {
-          lspserver::TextEdit Edit;
-          Edit.range = EditRange;
-          Edit.newText = Item.insertText;
-
-          Item.textEdit = Edit;
-        }
-
+        Item.textEdit = MkTextEdit(Item.insertText);
         addItem(Items, std::move(Item));
       }
     }

--- a/nixd/tools/nixd/test/completion/dot.md
+++ b/nixd/tools/nixd/test/completion/dot.md
@@ -59,7 +59,20 @@ CHECK-NEXT:        "data": "",
 CHECK-NEXT:        "detail": "nixos",
 CHECK-NEXT:        "kind": 7,
 CHECK-NEXT:        "label": "foo",
-CHECK-NEXT:        "score": 0
+CHECK-NEXT:        "score": 0,
+CHECK-NEXT:        "textEdit": {
+CHECK-NEXT:          "newText": "foo",
+CHECK-NEXT:          "range": {
+CHECK-NEXT:            "end": {
+CHECK-NEXT:              "character": 14,
+CHECK-NEXT:              "line": 0
+CHECK-NEXT:            },
+CHECK-NEXT:            "start": {
+CHECK-NEXT:              "character": 11,
+CHECK-NEXT:              "line": 0
+CHECK-NEXT:            }
+CHECK-NEXT:          }        
+CHECK-NEXT:        }
 CHECK-NEXT:      }
 CHECK-NEXT:    ]
 CHECK-NEXT:  }

--- a/nixd/tools/nixd/test/completion/nested.md
+++ b/nixd/tools/nixd/test/completion/nested.md
@@ -61,7 +61,20 @@ CHECK-NEXT:       "insertText": "bar = ;",
 CHECK-NEXT:       "insertTextFormat": 1,
 CHECK-NEXT:       "kind": 4,
 CHECK-NEXT:       "label": "bar",
-CHECK-NEXT:       "score": 0
+CHECK-NEXT:       "score": 0,
+CHECK-NEXT:       "textEdit": {
+CHECK-NEXT:         "newText": "bar = ;",
+CHECK-NEXT:         "range": {
+CHECK-NEXT:           "end": {
+CHECK-NEXT:             "character": 21,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           },
+CHECK-NEXT:           "start": {
+CHECK-NEXT:             "character": 19,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           }
+CHECK-NEXT:         }
+CHECK-NEXT:       }
 CHECK-NEXT:     }
 CHECK-NEXT:   ]
 ```

--- a/nixd/tools/nixd/test/completion/nixpkgs.md
+++ b/nixd/tools/nixd/test/completion/nixpkgs.md
@@ -61,13 +61,39 @@ CHECK-NEXT:      {
 CHECK-NEXT:        "data": "{\"Prefix\":\"a\",\"Scope\":[]}",
 CHECK-NEXT:        "kind": 5,
 CHECK-NEXT:        "label": "ax",
-CHECK-NEXT:        "score": 0
+CHECK-NEXT:        "score": 0,
+CHECK-NEXT:        "textEdit": {
+CHECK-NEXT:          "newText": "ax",
+CHECK-NEXT:          "range": {
+CHECK-NEXT:            "end": {
+CHECK-NEXT:              "character": 14,
+CHECK-NEXT:              "line": 0
+CHECK-NEXT:            },
+CHECK-NEXT:            "start": {
+CHECK-NEXT:              "character": 13,
+CHECK-NEXT:              "line": 0 
+CHECK-NEXT:            }
+CHECK-NEXT:          } 
+CHECK-NEXT:        }
 CHECK-NEXT:      },
 CHECK-NEXT:      {
 CHECK-NEXT:        "data": "{\"Prefix\":\"a\",\"Scope\":[]}",
 CHECK-NEXT:        "kind": 5,
 CHECK-NEXT:        "label": "ay",
-CHECK-NEXT:        "score": 0
+CHECK-NEXT:        "score": 0,
+CHECK-NEXT:        "textEdit": {
+CHECK-NEXT:          "newText": "ay",
+CHECK-NEXT:          "range": {
+CHECK-NEXT:            "end": {
+CHECK-NEXT:              "character": 14,
+CHECK-NEXT:              "line": 0 
+CHECK-NEXT:            },
+CHECK-NEXT:            "start": {
+CHECK-NEXT:              "character": 13,
+CHECK-NEXT:              "line": 0
+CHECK-NEXT:            } 
+CHECK-NEXT:          }
+CHECK-NEXT:        }
 CHECK-NEXT:      }
 CHECK-NEXT:    ]
 CHECK-NEXT:  }

--- a/nixd/tools/nixd/test/completion/options-default-only.md
+++ b/nixd/tools/nixd/test/completion/options-default-only.md
@@ -73,7 +73,20 @@ CHECK-NEXT:       "insertTextFormat": 2,
 CHECK-NEXT:       "kind": 4,
 CHECK-NEXT:       "label": "bar",
 CHECK-NEXT:       "score": 0,
-CHECK-NEXT:       "sortText": "1bar"
+CHECK-NEXT:       "sortText": "1bar",
+CHECK-NEXT:       "textEdit": {
+CHECK-NEXT:         "newText": "bar = ${1:pkgs.stdenv.hostPlatform.isLinux};",
+CHECK-NEXT:         "range": {
+CHECK-NEXT:           "end": {
+CHECK-NEXT:             "character": 17,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           },
+CHECK-NEXT:           "start": {
+CHECK-NEXT:             "character": 15,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           }
+CHECK-NEXT:         }
+CHECK-NEXT:       }
 CHECK-NEXT:     }
 CHECK-NEXT:   ]
 CHECK-NEXT: }

--- a/nixd/tools/nixd/test/completion/options-default.md
+++ b/nixd/tools/nixd/test/completion/options-default.md
@@ -76,7 +76,20 @@ CHECK-NEXT:       "insertTextFormat": 2,
 CHECK-NEXT:       "kind": 4,
 CHECK-NEXT:       "label": "bar (example)",
 CHECK-NEXT:       "score": 0,
-CHECK-NEXT:       "sortText": "0bar"
+CHECK-NEXT:       "sortText": "0bar",
+CHECK-NEXT:       "textEdit": {
+CHECK-NEXT:         "newText": "bar = ${1:true};",
+CHECK-NEXT:         "range": {
+CHECK-NEXT:           "end": {
+CHECK-NEXT:             "character": 17,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           },
+CHECK-NEXT:           "start": {
+CHECK-NEXT:             "character": 15,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           }
+CHECK-NEXT:         }
+CHECK-NEXT:       }
 CHECK-NEXT:     },
 CHECK-NEXT:     {
 CHECK-NEXT:       "data": "",
@@ -88,7 +101,20 @@ CHECK-NEXT:       "insertTextFormat": 2,
 CHECK-NEXT:       "kind": 4,
 CHECK-NEXT:       "label": "bar (default)",
 CHECK-NEXT:       "score": 0,
-CHECK-NEXT:       "sortText": "1bar"
+CHECK-NEXT:       "sortText": "1bar",
+CHECK-NEXT:       "textEdit": {
+CHECK-NEXT:         "newText": "bar = ${1:pkgs.stdenv.hostPlatform.isLinux};",
+CHECK-NEXT:         "range": {
+CHECK-NEXT:           "end": {
+CHECK-NEXT:             "character": 17,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           }
+CHECK-NEXT:           "start": {
+CHECK-NEXT:             "character": 15,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           }
+CHECK-NEXT:         }
+CHECK-NEXT:       }
 CHECK-NEXT:     }
 CHECK-NEXT:   ]
 CHECK-NEXT: }

--- a/nixd/tools/nixd/test/completion/options-in-config.md
+++ b/nixd/tools/nixd/test/completion/options-in-config.md
@@ -58,7 +58,20 @@ CHECK-NEXT:        "data": "",
 CHECK-NEXT:        "detail": "nixos",
 CHECK-NEXT:        "kind": 7,
 CHECK-NEXT:        "label": "foo",
-CHECK-NEXT:        "score": 0
+CHECK-NEXT:        "score": 0,
+CHECK-NEXT:        "textEdit": {
+CHECK-NEXT:          "newText": "foo",
+CHECK-NEXT:          "range": {
+CHECK-NEXT:            "end": {
+CHECK-NEXT:              "character": 16,
+CHECK-NEXT:              "line": 0
+CHECK-NEXT:            },
+CHECK-NEXT:            "start": {
+CHECK-NEXT:              "character": 13,
+CHECK-NEXT:              "line": 0
+CHECK-NEXT:            } 
+CHECK-NEXT:          } 
+CHECK-NEXT:        }
 CHECK-NEXT:      }
 CHECK-NEXT:    ]
 CHECK-NEXT:  }

--- a/nixd/tools/nixd/test/completion/options-mid.md
+++ b/nixd/tools/nixd/test/completion/options-mid.md
@@ -58,7 +58,20 @@ CHECK-NEXT:        "data": "",
 CHECK-NEXT:        "detail": "nixos",
 CHECK-NEXT:        "kind": 7,
 CHECK-NEXT:        "label": "foo",
-CHECK-NEXT:        "score": 0
+CHECK-NEXT:        "score": 0,
+CHECK-NEXT:        "textEdit": {
+CHECK-NEXT:          "newText": "foo",
+CHECK-NEXT:          "range": {
+CHECK-NEXT:            "end": {
+CHECK-NEXT:              "character": 13,
+CHECK-NEXT:              "line": 0 
+CHECK-NEXT:            },
+CHECK-NEXT:            "start": {
+CHECK-NEXT:              "character": 11,
+CHECK-NEXT:              "line": 0
+CHECK-NEXT:            }
+CHECK-NEXT:          }  
+CHECK-NEXT:        }
 CHECK-NEXT:      }
 CHECK-NEXT:    ]
 CHECK-NEXT:  }

--- a/nixd/tools/nixd/test/completion/options-no-snippet.md
+++ b/nixd/tools/nixd/test/completion/options-no-snippet.md
@@ -61,7 +61,20 @@ CHECK-NEXT:       "insertText": "bar = ;",
 CHECK-NEXT:       "insertTextFormat": 1,
 CHECK-NEXT:       "kind": 4,
 CHECK-NEXT:       "label": "bar",
-CHECK-NEXT:       "score": 0
+CHECK-NEXT:       "score": 0,
+CHECK-NEXT:       "textEdit": {
+CHECK-NEXT:         "newText": "bar = ;",
+CHECK-NEXT:         "range": {
+CHECK-NEXT:           "end": {
+CHECK-NEXT:             "character": 17,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           },
+CHECK-NEXT:           "start": {
+CHECK-NEXT:             "character": 15,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           }
+CHECK-NEXT:         } 
+CHECK-NEXT:       }
 CHECK-NEXT:     }
 CHECK-NEXT:   ]
 ```

--- a/nixd/tools/nixd/test/completion/options-snippet.md
+++ b/nixd/tools/nixd/test/completion/options-snippet.md
@@ -68,7 +68,20 @@ CHECK-NEXT:        "insertText": "bar = ${1:};",
 CHECK-NEXT:        "insertTextFormat": 2,
 CHECK-NEXT:        "kind": 4,
 CHECK-NEXT:        "label": "bar",
-CHECK-NEXT:        "score": 0
+CHECK-NEXT:        "score": 0,
+CHECK-NEXT:        "textEdit": {
+CHECK-NEXT:          "newText": "bar = ${1:};",
+CHECK-NEXT:          "range": {
+CHECK-NEXT:            "end": {
+CHECK-NEXT:              "character": 17,
+CHECK-NEXT:              "line": 0 
+CHECK-NEXT:            },
+CHECK-NEXT:            "start": {
+CHECK-NEXT:              "character": 15,
+CHECK-NEXT:              "line": 0
+CHECK-NEXT:            }
+CHECK-NEXT:          }
+CHECK-NEXT:        }
 CHECK-NEXT:      }
 CHECK-NEXT:    ]
 CHECK-NEXT:  }

--- a/nixd/tools/nixd/test/completion/options.md
+++ b/nixd/tools/nixd/test/completion/options.md
@@ -58,7 +58,20 @@ CHECK-NEXT:        "data": "",
 CHECK-NEXT:        "detail": "nixos",
 CHECK-NEXT:        "kind": 7,
 CHECK-NEXT:        "label": "foo",
-CHECK-NEXT:        "score": 0
+CHECK-NEXT:        "score": 0,
+CHECK-NEXT:        "textEdit": {
+CHECK-NEXT:          "newText": "foo",
+CHECK-NEXT:          "range": {
+CHECK-NEXT:            "end": {
+CHECK-NEXT:              "character": 13,
+CHECK-NEXT:              "line": 0 
+CHECK-NEXT:            },
+CHECK-NEXT:            "start": {
+CHECK-NEXT:              "character": 11,
+CHECK-NEXT:              "line": 0 
+CHECK-NEXT:            }
+CHECK-NEXT:          }
+CHECK-NEXT:        }
 CHECK-NEXT:      }
 CHECK-NEXT:    ]
 CHECK-NEXT:  }

--- a/nixd/tools/nixd/test/completion/select-lib.md
+++ b/nixd/tools/nixd/test/completion/select-lib.md
@@ -55,7 +55,20 @@ CHECK-NEXT:      {
 CHECK-NEXT:        "data": "{\"Prefix\":\"hel\",\"Scope\":[\"lib\"]}",
 CHECK-NEXT:        "kind": 5,
 CHECK-NEXT:        "label": "hello",
-CHECK-NEXT:        "score": 0
+CHECK-NEXT:        "score": 0,
+CHECK-NEXT:        "textEdit": {
+CHECK-NEXT:          "newText": "hello",
+CHECK-NEXT:          "range": {
+CHECK-NEXT:            "end": {
+CHECK-NEXT:              "character": 7,
+CHECK-NEXT:              "line": 0 
+CHECK-NEXT:            },
+CHECK-NEXT:            "start": {
+CHECK-NEXT:              "character": 4,
+CHECK-NEXT:              "line": 0
+CHECK-NEXT:            }
+CHECK-NEXT:          } 
+CHECK-NEXT:        }
 CHECK-NEXT:      }
 CHECK-NEXT:    ]
 ```

--- a/nixd/tools/nixd/test/completion/select.md
+++ b/nixd/tools/nixd/test/completion/select.md
@@ -55,7 +55,20 @@ CHECK-NEXT:      {
 CHECK-NEXT:        "data": "{\"Prefix\":\"hel\",\"Scope\":[]}",
 CHECK-NEXT:        "kind": 5,
 CHECK-NEXT:        "label": "hello",
-CHECK-NEXT:        "score": 0
+CHECK-NEXT:        "score": 0,
+CHECK-NEXT:        "textEdit": {
+CHECK-NEXT:          "newText": "hello",
+CHECK-NEXT:          "range": {
+CHECK-NEXT:            "end": {
+CHECK-NEXT:              "character": 8,
+CHECK-NEXT:              "line": 0 
+CHECK-NEXT:            },
+CHECK-NEXT:            "start": {
+CHECK-NEXT:              "character": 5,
+CHECK-NEXT:              "line": 0
+CHECK-NEXT:            }
+CHECK-NEXT:          } 
+CHECK-NEXT:        }
 CHECK-NEXT:      }
 CHECK-NEXT:    ]
 ```

--- a/nixd/tools/nixd/test/completion/with-expr-select.md
+++ b/nixd/tools/nixd/test/completion/with-expr-select.md
@@ -49,12 +49,38 @@ with pkgs.ax; [ b ]
      CHECK:    "data": "{\"Prefix\":\"b\",\"Scope\":[\"ax\"]}",
 CHECK-NEXT:    "kind": 5,
 CHECK-NEXT:    "label": "bx",
-CHECK-NEXT:    "score": 0
+CHECK-NEXT:    "score": 0,
+CHECK-NEXT:    "textEdit": {
+CHECK-NEXT:      "newText": "bx",
+CHECK-NEXT:      "range": {
+CHECK-NEXT:        "end": {
+CHECK-NEXT:          "character": 17,
+CHECK-NEXT:          "line": 0 
+CHECK-NEXT:        },
+CHECK-NEXT:        "start": {
+CHECK-NEXT:          "character": 16,
+CHECK-NEXT:          "line": 0 
+CHECK-NEXT:        } 
+CHECK-NEXT:      }
+CHECK-NEXT:    }
 CHECK-NEXT:  },
 CHECK-NEXT:  {
 CHECK-NEXT:    "data": "{\"Prefix\":\"b\",\"Scope\":[\"ax\"]}",
 CHECK-NEXT:    "kind": 5,
 CHECK-NEXT:    "label": "by",
-CHECK-NEXT:    "score": 0
+CHECK-NEXT:    "score": 0,
+CHECK-NEXT:    "textEdit": {
+CHECK-NEXT:      "newText": "by",
+CHECK-NEXT:      "range": {
+CHECK-NEXT:        "end": {
+CHECK-NEXT:          "character": 17,
+CHECK-NEXT:          "line": 0 
+CHECK-NEXT:        },
+CHECK-NEXT:        "start": {
+CHECK-NEXT:          "character": 16,
+CHECK-NEXT:          "line": 0 
+CHECK-NEXT:        } 
+CHECK-NEXT:      }
+CHECK-NEXT:    }
 CHECK-NEXT:  }
 ```

--- a/nixd/tools/nixd/test/completion/with-select.md
+++ b/nixd/tools/nixd/test/completion/with-select.md
@@ -55,13 +55,39 @@ CHECK-NEXT:     {
 CHECK-NEXT:       "data": "{\"Prefix\":\"b\",\"Scope\":[\"ax\"]}",
 CHECK-NEXT:       "kind": 5,
 CHECK-NEXT:       "label": "bx",
-CHECK-NEXT:       "score": 0
+CHECK-NEXT:       "score": 0,
+CHECK-NEXT:       "textEdit": {
+CHECK-NEXT:         "newText": "bx",
+CHECK-NEXT:         "range": {
+CHECK-NEXT:           "end": {
+CHECK-NEXT:             "character": 17,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           },
+CHECK-NEXT:           "start": {
+CHECK-NEXT:             "character": 16,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           }
+CHECK-NEXT:         }  
+CHECK-NEXT:       }
 CHECK-NEXT:     },
 CHECK-NEXT:     {
 CHECK-NEXT:       "data": "{\"Prefix\":\"b\",\"Scope\":[\"ax\"]}",
 CHECK-NEXT:       "kind": 5,
 CHECK-NEXT:       "label": "by",
-CHECK-NEXT:       "score": 0
+CHECK-NEXT:       "score": 0,
+CHECK-NEXT:       "textEdit": {
+CHECK-NEXT:         "newText": "by",
+CHECK-NEXT:         "range": {
+CHECK-NEXT:           "end": {
+CHECK-NEXT:             "character": 17,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           },
+CHECK-NEXT:           "start": {
+CHECK-NEXT:             "character": 16,
+CHECK-NEXT:             "line": 0
+CHECK-NEXT:           }
+CHECK-NEXT:         }
+CHECK-NEXT:       }
 CHECK-NEXT:     }
 CHECK-NEXT:   ]
 ```


### PR DESCRIPTION
Adds rudimentary [textEdit](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit) support for completions.
This fixes https://github.com/helix-editor/helix/issues/12540 where due to word boundary rules it doesn't fully replace items containing a hyphen
I have left this as a draft as my implementation was very quickly put together and as I'm not too familiar with either c++ or the code base, there is probably a different approach that you would prefer.