### PR TITLE
enhancement: support tilde (`~`) path

### DIFF
--- a/libnixf/src/Parse/Lexer.cpp
+++ b/libnixf/src/Parse/Lexer.cpp
@@ -212,13 +212,28 @@ void Lexer::lexNumbers() {
 bool Lexer::consumePathStart() {
   // PATH_CHAR   [a-zA-Z0-9\.\_\-\+]
   // PATH        {PATH_CHAR}*(\/{PATH_CHAR}+)+\/?
+  // HOME_PATH   ~\/{PATH_CHAR}+
   // PATH_SEG    {PATH_CHAR}*\/
   //
 
-  // Path, starts with any valid path char, and must contain slashs
-  // Here, we look ahead characters, the must be valid path char
-  // And also check if it contains a slash.
+  // Path, starts with any valid path char, or a leading "~/" home path, and
+  // must contain slashs Here, we look ahead characters, the must be valid path
+  // char And also check if it contains a slash.
   LexerCursor Saved = cur();
+
+  // Nix accepts paths under the user's home directory, e.g. ~/foo. The '~'
+  // marker is only valid as a path start when immediately followed by '/'.
+  // Keep '~foo/bar' and interior '~' segments rejected, matching libexpr.
+  if (consumeOne('~')) {
+    if (consumeOne('/')) {
+      if (auto Ch = peek(); Ch && isPathChar(*Ch))
+        return true;
+      if (peekPrefix("${"))
+        return true;
+    }
+    Cur = Saved;
+    return false;
+  }
 
   // {PATH_CHAR}*
   consumeManyPathChar();
@@ -341,6 +356,18 @@ Token Lexer::lexPath() {
     return finishToken();
   }
 
+  if (peekPrefix("~/")) {
+    Tok = tok_path_fragment;
+    consume(2);
+    while (!eof() && (isPathChar(peekUnwrap()) || peekUnwrap() == '/')) {
+      // Encountered an interpolation, stop here
+      if (peekPrefix("${"))
+        break;
+      consume();
+    }
+    return finishToken();
+  }
+
   if (isPathChar(peekUnwrap()) || peekUnwrap() == '/') {
     Tok = tok_path_fragment;
     while (!eof() && (isPathChar(peekUnwrap()) || peekUnwrap() == '/')) {
@@ -456,7 +483,7 @@ Token Lexer::lex() {
 
   // Determine if this is a path, or identifier.
   // a/b (including 1/2) should be considered as a whole path, not (a / b)
-  if (isPathChar(*Ch) || *Ch == '/') {
+  if (isPathChar(*Ch) || *Ch == '/' || *Ch == '~') {
     if (consumePathStart()) {
       // Form a concret token, this is a path part.
       Tok = tok_path_fragment;

--- a/libnixf/test/Parse/Lexer.cpp
+++ b/libnixf/test/Parse/Lexer.cpp
@@ -173,6 +173,32 @@ TEST_F(LexerTest, lexIDPath) {
   ASSERT_EQ(Tokens.size(), sizeof(Match) / sizeof(TokenKind));
 }
 
+TEST_F(LexerTest, lexHomePathStart) {
+  Lexer Lexer(R"(~/foo/bar.nix)", Diags);
+  Token First = Lexer.lex();
+  ASSERT_EQ(First.kind(), tok_path_fragment);
+  ASSERT_EQ(First.view(), "~/");
+
+  Token Rest = Lexer.lexPath();
+  ASSERT_EQ(Rest.kind(), tok_path_fragment);
+  ASSERT_EQ(Rest.view(), "foo/bar.nix");
+
+  Token End = Lexer.lexPath();
+  ASSERT_EQ(End.kind(), tok_path_end);
+  ASSERT_TRUE(Diags.empty());
+}
+
+TEST_F(LexerTest, lexHomePathInterpolationStart) {
+  Lexer Lexer(R"(~/${"subdir"}/file.nix)", Diags);
+  Token First = Lexer.lex();
+  ASSERT_EQ(First.kind(), tok_path_fragment);
+  ASSERT_EQ(First.view(), "~/");
+
+  Token Interpolation = Lexer.lexPath();
+  ASSERT_EQ(Interpolation.kind(), tok_dollar_curly);
+  ASSERT_TRUE(Diags.empty());
+}
+
 TEST_F(LexerTest, lexKW) {
   // FIXME: test  pp//a to see that we can lex this as Update(pp, a)
   Lexer Lexer(R"(if then)", Diags);

--- a/libnixf/test/Parse/ParseExpr.cpp
+++ b/libnixf/test/Parse/ParseExpr.cpp
@@ -152,6 +152,22 @@ TEST(Parser, ParseExprApp) {
   ASSERT_EQ(A->args().size(), 1);
 }
 
+TEST(Parser, ParseExprAppHomePathArg) {
+  auto Src = R"(builtins.pathExists ~/some/file.nix)"sv;
+
+  std::vector<Diagnostic> Diags;
+  Parser P(Src, Diags);
+  auto AST = P.parse();
+
+  ASSERT_TRUE(AST);
+  ASSERT_EQ(Diags.size(), 0);
+  ASSERT_EQ(AST->kind(), Node::NK_ExprCall);
+
+  const auto &Call = static_cast<ExprCall &>(*AST);
+  ASSERT_EQ(Call.args().size(), 1);
+  ASSERT_EQ(Call.args()[0]->kind(), Node::NK_ExprPath);
+}
+
 TEST(Parser, ExprDispatch_id_at) {
   // ID @
   auto Src = R"(a @)"sv;

--- a/libnixf/test/Parse/ParseSimple.cpp
+++ b/libnixf/test/Parse/ParseSimple.cpp
@@ -354,6 +354,39 @@ TEST(Parser, PathOK) {
   ASSERT_EQ(Parts.fragments()[2].escaped(), "/d");
 }
 
+TEST(Parser, HomePathOK) {
+  auto Src = R"(~/foo/bar.nix)"sv;
+
+  std::vector<Diagnostic> Diags;
+  auto AST = nixf::parse(Src, Diags);
+  ASSERT_TRUE(AST);
+  ASSERT_EQ(AST->kind(), Node::NK_ExprPath);
+  ASSERT_EQ(Diags.size(), 0);
+
+  const auto &Parts = static_cast<ExprPath *>(AST.get())->parts();
+  ASSERT_EQ(Parts.fragments().size(), 1);
+  ASSERT_EQ(Parts.fragments()[0].kind(), InterpolablePart::SPK_Escaped);
+  ASSERT_EQ(Parts.fragments()[0].escaped(), "~/foo/bar.nix");
+}
+
+TEST(Parser, HomePathInterpolationOK) {
+  auto Src = R"(~/${"subdir"}/file.nix)"sv;
+
+  std::vector<Diagnostic> Diags;
+  auto AST = nixf::parse(Src, Diags);
+  ASSERT_TRUE(AST);
+  ASSERT_EQ(AST->kind(), Node::NK_ExprPath);
+  ASSERT_EQ(Diags.size(), 0);
+
+  const auto &Parts = static_cast<ExprPath *>(AST.get())->parts();
+  ASSERT_EQ(Parts.fragments().size(), 3);
+  ASSERT_EQ(Parts.fragments()[0].kind(), InterpolablePart::SPK_Escaped);
+  ASSERT_EQ(Parts.fragments()[0].escaped(), "~/");
+  ASSERT_EQ(Parts.fragments()[1].kind(), InterpolablePart::SPK_Interpolation);
+  ASSERT_EQ(Parts.fragments()[2].kind(), InterpolablePart::SPK_Escaped);
+  ASSERT_EQ(Parts.fragments()[2].escaped(), "/file.nix");
+}
+
 TEST(Parser, SPath) {
   auto Src = R"(<nixpkgs>)"sv;
 


### PR DESCRIPTION
Note: this fix was developed with assistance from Hermes Agent (gpt-5.5). I have reviewed the fix and tests, and have verified them in my daily workflow.

Fixes https://github.com/nix-community/nixd/issues/708 by teaching the nixf lexer/parser to recognize Nix home-directory paths that start with `~/`, such as `~/mydir` and `~/foo/bar.nix`.

## Changes

- Recognize `~/` as a valid path start in expression lexing (`consumePathStart`).
- Recognize `~/` when lexing in path mode (`lexPath`), so the parser can re-lex the first path fragment after switching into path context.
- Add lexer regression tests for `~/...` and `~/${...}` path starts.
- Add parser regression tests for literal paths, interpolated paths, and function-application arguments (e.g. `builtins.pathExists ~/some/file.nix`).

## Testing

Ran the targeted unit tests in the development shell:

```console
$ nix develop --command bash -lc 'meson test -C build --print-errorlogs unit/libnixf/Basic unit/libnixf/Parse unit/libnixt'
1/3 nixd:unit/libnixf/Basic OK
2/3 nixd:unit/libnixf/Parse OK
3/3 nixd:unit/libnixt       OK

Ok:                3
Fail:              0
```

Manually verified zero diagnostics on tilde-prefixed paths via `nixf-tidy`:

```console
$ printf '%s' '~/foo/bar.nix' | ./build/libnixf/tools/nixf-tidy --pretty-print
[]

$ printf '%s' 'builtins.pathExists ~/some/file.nix' | ./build/libnixf/tools/nixf-tidy --pretty-print
[]
```