### PR TITLE
nixd/Hover: return null when rendered markdown is empty (fix LSP spec violation)

### DIFF
--- a/nixd/lib/Controller/Hover.cpp
+++ b/nixd/lib/Controller/Hover.cpp
@@ -138,7 +138,11 @@ public:
     if (!Info)
       return std::nullopt;
 
-    return mkMarkdown(*Info);
+    auto Md = mkMarkdown(*Info);
+    if (Md.empty())
+      return std::nullopt;
+
+    return Md;
   }
 };
 

--- a/nixd/tools/nixd/test/hover/empty-payload.md
+++ b/nixd/tools/nixd/test/hover/empty-payload.md
@@ -1,0 +1,58 @@
+# RUN: nixd --lit-test \
+# RUN: --nixpkgs-expr="{ undocumented = x: x; }" \
+# RUN: < %s | FileCheck %s
+
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///basic.nix
+pkgs.undocumented
+```
+
+<-- textDocument/hover(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/hover",
+   "params":{
+      "textDocument":{
+         "uri":"file:///basic.nix"
+      },
+      "position":{
+         "line":0,
+         "character":7
+      }
+   }
+}
+```
+
+```
+     CHECK: "id": 2,
+CHECK-NEXT: "jsonrpc": "2.0",
+CHECK-NEXT: "result": null
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```


### PR DESCRIPTION
### Repro

For a nixpkgs selector that resolves but has no package metadata and no value description (e.g. any undocumented lambda like `lib.mkMerge`), `textDocument/hover` currently emits

    "result": { "contents": null, "range": { ... } }

rather than the expected `"result": null`. The new `nixd/tools/nixd/test/hover/empty-payload.md` lit fixture in this PR reproduces this end-to-end against a synthetic nixpkgs containing an undocumented lambda.

### Spec violation

Per [LSP 3.17 textDocument/hover][hover-spec], `Hover.contents` is required and non-nullable:

    interface Hover {
      contents: MarkedString | MarkedString[] | MarkupContent;
      range?: Range;
    }

The whole `result` may be `null` (meaning "no hover"), but if a `Hover` is present, its `contents` field must be one of the three string-bearing types — not `null`. The current output violates this.

In practice, this surfaces in Claude Code's LSP integration as a tool-level error rather than the correct "no hover info" outcome:

    Error performing hover: null is not an Object. (evaluating '"kind"in H')

The session continues working — only this particular hover request fails — but the client is correct to assume contents is non-null per spec, so the fix belongs here.

### Fix

When the rendered markdown for a hover response is empty, return `std::nullopt` from `resolveSelector` so the LSP reply is the spec-conformant `"result": null`.

### Test

`nixd/tools/nixd/test/hover/empty-payload.md` covers this case. Verified locally that the new fixture fails against the unpatched binary (the pre-fix `"result": {"contents": null, ...}` doesn't match the expected `"result": null`) and passes with the patch applied. Full `lit ./nixd/tools/nixd/test` passes 188/188 with the patch; no other tests change behavior.

[hover-spec]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover
