### PR TITLE
fix(code-action): preserve non-matching bindings in bulk Pack All

### DIFF
--- a/nixd/lib/Controller/CodeActions/PackAttrs.cpp
+++ b/nixd/lib/Controller/CodeActions/PackAttrs.cpp
@@ -8,7 +8,7 @@
 
 #include <nixf/Basic/Nodes/Attrs.h>
 
-#include <optional>
+#include <vector>
 
 namespace nixd {
 
@@ -152,14 +152,12 @@ void generateShallowNestedText(const nixf::Binds &Binds,
   Out += " }";
 }
 
-/// \brief Find all sibling bindings that share the same first path segment.
-/// Returns the range covering all such bindings, or nullopt if not applicable.
-std::optional<nixf::LexerCursorRange>
-findSiblingBindingsRange(const nixf::Binding &Bind, const nixf::Binds &Binds,
-                         const std::string &FirstSeg) {
-  nixf::LexerCursor Start = Bind.range().lCur();
-  nixf::LexerCursor End = Bind.range().rCur();
-
+/// \brief Find all sibling bindings whose first path segment matches FirstSeg.
+/// Returns pointers in source order. Caller must ensure the vector is non-empty
+/// before use.
+std::vector<const nixf::Binding *>
+collectSiblingBindings(const nixf::Binds &Binds, const std::string &FirstSeg) {
+  std::vector<const nixf::Binding *> Result;
   for (const auto &Sibling : Binds.bindings()) {
     if (Sibling->kind() != nixf::Node::NK_Binding)
       continue;
@@ -170,16 +168,10 @@ findSiblingBindingsRange(const nixf::Binding &Bind, const nixf::Binds &Binds,
     if (SibNames.empty() || !SibNames[0]->isStatic())
       continue;
 
-    if (SibNames[0]->staticName() == FirstSeg) {
-      // Expand range to include this sibling
-      if (SibBind.range().lCur().offset() < Start.offset())
-        Start = SibBind.range().lCur();
-      if (SibBind.range().rCur().offset() > End.offset())
-        End = SibBind.range().rCur();
-    }
+    if (SibNames[0]->staticName() == FirstSeg)
+      Result.push_back(&SibBind);
   }
-
-  return nixf::LexerCursorRange{Start, End};
+  return Result;
 }
 
 } // namespace
@@ -279,10 +271,12 @@ void addPackAttrsAction(const nixf::Node &N, const nixf::ParentMapAnalysis &PM,
     const auto &NestedAttrs =
         static_cast<const nixf::ExprAttrs &>(*Attr.value());
 
-    // Find the range covering all sibling bindings (needed for bulk actions)
+    // Collect all matching sibling bindings in source order. Bulk actions
+    // emit one TextEdit per binding so intermediate non-matching bindings
+    // (e.g. `b.y = 2` in `{ a.x = 1; b.y = 2; a.z = 3; }`) are preserved.
     const auto &ParentBinds = static_cast<const nixf::Binds &>(*BindsNode);
-    auto BulkRange = findSiblingBindingsRange(Bind, ParentBinds, FirstSeg);
-    if (!BulkRange)
+    auto Matches = collectSiblingBindings(ParentBinds, FirstSeg);
+    if (Matches.empty())
       return;
 
     // Action 1: Pack One - pack only the current binding
@@ -294,6 +288,25 @@ void addPackAttrsAction(const nixf::Node &N, const nixf::ParentMapAnalysis &PM,
           toLSPRange(Src, Bind.range()), std::move(PackOneText)));
     }
 
+    // Build a vector of TextEdits that replaces the first matching binding
+    // with `PackedText` and deletes every other matching binding in place.
+    auto BuildBulkEdits =
+        [&](std::string PackedText) -> std::vector<lspserver::TextEdit> {
+      std::vector<lspserver::TextEdit> Edits;
+      Edits.reserve(Matches.size());
+      Edits.emplace_back(lspserver::TextEdit{
+          .range = toLSPRange(Src, Matches.front()->range()),
+          .newText = std::move(PackedText),
+      });
+      for (size_t I = 1; I < Matches.size(); ++I) {
+        Edits.emplace_back(lspserver::TextEdit{
+            .range = toLSPRange(Src, Matches[I]->range()),
+            .newText = "",
+        });
+      }
+      return Edits;
+    };
+
     // Action 2: Shallow Pack All - pack all siblings but only one level deep
     std::string ShallowText;
     ShallowText += quoteNixAttrKey(FirstSeg);
@@ -301,10 +314,10 @@ void addPackAttrsAction(const nixf::Node &N, const nixf::ParentMapAnalysis &PM,
     generateShallowNestedText(ParentBinds, FirstSeg, Src, ShallowText);
     ShallowText += ";";
 
-    Actions.emplace_back(createSingleEditAction(
+    Actions.emplace_back(createMultiEditAction(
         "Pack all '" + FirstSeg + "' bindings to nested set",
         lspserver::CodeAction::REFACTOR_REWRITE_KIND, FileURI,
-        toLSPRange(Src, *BulkRange), std::move(ShallowText)));
+        BuildBulkEdits(std::move(ShallowText))));
 
     // Action 3: Recursive Pack All - fully nest all sibling bindings
     std::string RecursiveText;
@@ -313,10 +326,10 @@ void addPackAttrsAction(const nixf::Node &N, const nixf::ParentMapAnalysis &PM,
     generateNestedText(NestedAttrs.sema(), Src, RecursiveText);
     RecursiveText += ";";
 
-    Actions.emplace_back(createSingleEditAction(
+    Actions.emplace_back(createMultiEditAction(
         "Recursively pack all '" + FirstSeg + "' bindings to nested set",
         lspserver::CodeAction::REFACTOR_REWRITE_KIND, FileURI,
-        toLSPRange(Src, *BulkRange), std::move(RecursiveText)));
+        BuildBulkEdits(std::move(RecursiveText))));
   }
 }
 

--- a/nixd/lib/Controller/CodeActions/Utils.cpp
+++ b/nixd/lib/Controller/CodeActions/Utils.cpp
@@ -24,6 +24,19 @@ lspserver::CodeAction createSingleEditAction(const std::string &Title,
   };
 }
 
+lspserver::CodeAction
+createMultiEditAction(const std::string &Title, llvm::StringLiteral Kind,
+                      const std::string &FileURI,
+                      std::vector<lspserver::TextEdit> Edits) {
+  using Changes = std::map<std::string, std::vector<lspserver::TextEdit>>;
+  lspserver::WorkspaceEdit WE{.changes = Changes{{FileURI, std::move(Edits)}}};
+  return lspserver::CodeAction{
+      .title = Title,
+      .kind = std::string(Kind),
+      .edit = std::move(WE),
+  };
+}
+
 bool isValidNixIdentifier(const std::string &S) {
   if (S.empty())
     return false;

--- a/nixd/lib/Controller/CodeActions/Utils.h
+++ b/nixd/lib/Controller/CodeActions/Utils.h
@@ -23,6 +23,15 @@ lspserver::CodeAction createSingleEditAction(const std::string &Title,
                                              const lspserver::Range &EditRange,
                                              std::string NewText);
 
+/// \brief Create a CodeAction with multiple text edits applied as one.
+///
+/// Per LSP, all edits in a single WorkspaceEdit are applied against the
+/// pre-edit document state, so callers must ensure ranges do not overlap.
+lspserver::CodeAction
+createMultiEditAction(const std::string &Title, llvm::StringLiteral Kind,
+                      const std::string &FileURI,
+                      std::vector<lspserver::TextEdit> Edits);
+
 /// \brief Check if a string is a valid Nix identifier that can be unquoted.
 ///
 /// Valid identifiers: start with letter or underscore, contain letters,

--- a/nixd/tools/nixd/test/code-action/pack-attrs/pack-attrs-bulk-non-contiguous.md
+++ b/nixd/tools/nixd/test/code-action/pack-attrs/pack-attrs-bulk-non-contiguous.md
@@ -61,34 +61,55 @@ Three Pack actions should be offered:
 2. Shallow Pack All - all 'foo' bindings (foo.a and foo.b), even though they are separated by 'bar'
 3. Recursive Pack All - all 'foo' bindings, fully nested
 
+For the bulk actions, the WorkspaceEdit must contain two TextEdits: one that
+replaces the first `foo.*` binding with the packed result, and one that deletes
+the second `foo.*` binding in place. The intermediate `bar = 2;` binding is
+left untouched in the source.
+
 ```
      CHECK:   "id": 2,
      CHECK:   "result": [
 CHECK-NEXT:     {
 ```
 
-Action 1: Pack One - only foo.a
+Action 1: Pack One - only foo.a, single edit replacing offset 2..12.
 
 ```
      CHECK:       "newText": "foo = { a = 1; };"
+CHECK-NEXT:       "range": {
+CHECK-NEXT:         "end": {
+CHECK-NEXT:           "character": 12,
      CHECK:       "title": "Pack dotted path to nested set"
 CHECK-NEXT:     },
 CHECK-NEXT:     {
 ```
 
-Action 2: Shallow Pack All - groups non-contiguous foo.a and foo.b bindings
+Action 2: Shallow Pack All - replaces foo.a with the packed text, then deletes foo.b. `bar = 2;` is preserved.
 
 ```
      CHECK:       "newText": "foo = { a = 1; b = 3; };"
+CHECK-NEXT:       "range": {
+CHECK-NEXT:         "end": {
+CHECK-NEXT:           "character": 12,
+     CHECK:       "newText": ""
+CHECK-NEXT:       "range": {
+CHECK-NEXT:         "end": {
+CHECK-NEXT:           "character": 32,
+     CHECK:           "character": 22,
      CHECK:       "title": "Pack all 'foo' bindings to nested set"
 CHECK-NEXT:     },
 CHECK-NEXT:     {
 ```
 
-Action 3: Recursive Pack All - same as shallow for single-level paths
+Action 3: Recursive Pack All - same shape (single-level path), two edits.
 
 ```
      CHECK:       "newText": "foo = { a = 1; b = 3; };"
+CHECK-NEXT:       "range": {
+     CHECK:       "newText": ""
+CHECK-NEXT:       "range": {
+CHECK-NEXT:         "end": {
+CHECK-NEXT:           "character": 32,
      CHECK:       "title": "Recursively pack all 'foo' bindings to nested set"
 CHECK-NEXT:     }
 CHECK-NEXT:   ]

--- a/nixd/tools/nixd/test/code-action/pack-attrs/pack-attrs-bulk-preserve-intermediate.md
+++ b/nixd/tools/nixd/test/code-action/pack-attrs/pack-attrs-bulk-preserve-intermediate.md
@@ -1,0 +1,126 @@
+# RUN: nixd --lit-test < %s | FileCheck %s
+
+Regression test for the bug where "Pack all" bulk actions silently dropped
+non-matching bindings sitting between matching siblings. With input
+
+```
+{
+  a.x = 1;
+  b.y = 2;
+  a.z = 3;
+}
+```
+
+the action incorrectly replaced the whole `a.x = 1; ... a.z = 3;` span with
+the packed `a = { x = 1; z = 3; };`, deleting `b.y = 2;`.
+
+The fix emits a multi-edit WorkspaceEdit:
+- replace the first matching binding with the full packed result,
+- delete every subsequent matching binding in place,
+- leave intermediate non-matching bindings untouched.
+
+<-- initialize(0)
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":0,
+   "method":"initialize",
+   "params":{
+      "processId":123,
+      "rootPath":"",
+      "capabilities":{
+      },
+      "trace":"off"
+   }
+}
+```
+
+
+<-- textDocument/didOpen
+
+```nix file:///pack-attrs-bulk-preserve-intermediate.nix
+{
+  a.x = 1;
+  b.y = 2;
+  a.z = 3;
+}
+```
+
+<-- textDocument/codeAction(2)
+
+
+```json
+{
+   "jsonrpc":"2.0",
+   "id":2,
+   "method":"textDocument/codeAction",
+   "params":{
+      "textDocument":{
+         "uri":"file:///pack-attrs-bulk-preserve-intermediate.nix"
+      },
+      "range":{
+         "start":{
+            "line": 1,
+            "character":2
+         },
+         "end":{
+            "line":1,
+            "character":5
+         }
+      },
+      "context":{
+         "diagnostics":[],
+         "triggerKind":2
+      }
+   }
+}
+```
+
+Action 1: Pack One - replaces just `a.x = 1;` on line 1.
+
+```
+     CHECK:   "result": [
+     CHECK:       "newText": "a = { x = 1; };"
+CHECK-NEXT:       "range": {
+CHECK-NEXT:         "end": {
+CHECK-NEXT:           "character": 10,
+CHECK-NEXT:           "line": 1
+     CHECK:       "title": "Pack dotted path to nested set"
+```
+
+Action 2: Shallow Pack All - replaces `a.x = 1;` on line 1 with the packed
+result and deletes `a.z = 3;` on line 3. `b.y = 2;` on line 2 is preserved.
+
+```
+     CHECK:       "newText": "a = { x = 1; z = 3; };"
+CHECK-NEXT:       "range": {
+CHECK-NEXT:         "end": {
+CHECK-NEXT:           "character": 10,
+CHECK-NEXT:           "line": 1
+     CHECK:       "newText": ""
+CHECK-NEXT:       "range": {
+CHECK-NEXT:         "end": {
+CHECK-NEXT:           "character": 10,
+CHECK-NEXT:           "line": 3
+     CHECK:           "character": 2,
+CHECK-NEXT:           "line": 3
+     CHECK:       "title": "Pack all 'a' bindings to nested set"
+```
+
+Action 3: Recursive Pack All - same two-edit shape for this single-level case.
+
+```
+     CHECK:       "newText": "a = { x = 1; z = 3; };"
+CHECK-NEXT:       "range": {
+     CHECK:       "newText": ""
+CHECK-NEXT:       "range": {
+CHECK-NEXT:         "end": {
+CHECK-NEXT:           "character": 10,
+CHECK-NEXT:           "line": 3
+     CHECK:       "title": "Recursively pack all 'a' bindings to nested set"
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```

--- a/nixd/tools/nixd/test/code-action/pack-attrs/pack-attrs-shallow-bulk.md
+++ b/nixd/tools/nixd/test/code-action/pack-attrs/pack-attrs-shallow-bulk.md
@@ -73,19 +73,27 @@ CHECK-NEXT:     },
 CHECK-NEXT:     {
 ```
 
-Action 2: Shallow Pack All - preserves bar.x as dotted path
+Action 2: Shallow Pack All - preserves bar.x as dotted path. The bulk action
+emits two edits: one that replaces the first `foo.*` binding with the packed
+text, and one that deletes the subsequent `foo.*` binding.
 
 ```
      CHECK:       "newText": "foo = { bar.x = 1; baz = 2; };"
+CHECK-NEXT:       "range": {
+     CHECK:       "newText": ""
+CHECK-NEXT:       "range": {
      CHECK:       "title": "Pack all 'foo' bindings to nested set"
 CHECK-NEXT:     },
 CHECK-NEXT:     {
 ```
 
-Action 3: Recursive Pack All - fully nests bar = { x = 1; }
+Action 3: Recursive Pack All - fully nests bar = { x = 1; }, again as two edits.
 
 ```
      CHECK:       "newText": "foo = { bar = { x = 1; }; baz = 2; };"
+CHECK-NEXT:       "range": {
+     CHECK:       "newText": ""
+CHECK-NEXT:       "range": {
      CHECK:       "title": "Recursively pack all 'foo' bindings to nested set"
 CHECK-NEXT:     }
 CHECK-NEXT:   ]


### PR DESCRIPTION
The bulk "Pack all 'X' bindings to nested set" and "Recursively pack all ..." actions computed a single contiguous range from the leftmost to the rightmost matching sibling and replaced it with the packed text. When matching siblings were non-contiguous, that range engulfed intermediate non-matching bindings, which the replacement silently dropped.

For example, `{ a.x = 1; b.y = 2; a.z = 3; }` produced `{ a = { x = 1; z = 3; }; }` instead of preserving `b.y = 2;`.

Emit a multi-edit WorkspaceEdit instead: replace the first matching binding with the packed text, then delete each subsequent matching binding in place. Intermediate non-matching bindings are left untouched.

Tighten the existing non-contiguous and shallow-bulk lit tests to verify the two-edit shape, and add a regression test that mirrors the original bug report.


Fixes: https://github.com/nix-community/nixd/issues/837