### PR TITLE
nixd/CheckReturn: use __extension__ for statement-expr

### DIFF
--- a/nixd/lib/Controller/CheckReturn.h
+++ b/nixd/lib/Controller/CheckReturn.h
@@ -4,7 +4,7 @@
 ///
 ///   const auto *foo = checkReturn(get(), nullptr)
 #define CheckReturn(x, Ret)                                                    \
-  ({                                                                           \
+  __extension__({                                                              \
     decltype(x) temp = (x);                                                    \
     if (!temp) [[unlikely]] {                                                  \
       return Ret;                                                              \


### PR DESCRIPTION
Refs: #851