### PR TITLE
build: add llvm_static option to statically link LLVM support

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,6 +11,9 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
+        # "nixd" links LLVMSupport statically (llvm_static=true, the default);
+        # "nixd-llvm-dynamic" links against the libLLVM dylib (llvm_static=false).
+        package: [ nixd, nixd-llvm-dynamic ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: cachix/install-nix-action@v31
@@ -22,4 +25,4 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - uses: actions/checkout@v6
     - name: Build flake
-      run: nix build -L #.
+      run: nix build -L .#${{ matrix.package }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,9 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        # "nixd" links LLVMSupport statically (llvm_static=true, the default);
-        # "nixd-llvm-dynamic" links against the libLLVM dylib (llvm_static=false).
-        package: [ nixd, nixd-llvm-dynamic ]
+        package: [ nixd, nixd-llvm-static ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: cachix/install-nix-action@v31

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,9 @@
             inherit nixComponents nixf nixt;
             inherit llvmPackages;
           };
+          # Same package linked against the libLLVM dylib instead; built in CI
+          # so the llvm_static=false configuration doesn't bitrot.
+          nixd-llvm-dynamic = nixd.override { llvmStatic = false; };
           nixdMono = callPackage ./. { inherit nixComponents llvmPackages; };
           nixdLLVM = nixdMono.override { stdenv = if stdenv.isDarwin then stdenv else llvmPackages.stdenv; };
           regressionDeps = with pkgs; [
@@ -69,7 +72,12 @@
             inherit (config.packages) nixd;
           };
           packages = {
-            inherit nixd nixf nixt;
+            inherit
+              nixd
+              nixd-llvm-dynamic
+              nixf
+              nixt
+              ;
           };
 
           devShells = {

--- a/flake.nix
+++ b/flake.nix
@@ -43,9 +43,7 @@
             inherit nixComponents nixf nixt;
             inherit llvmPackages;
           };
-          # Same package linked against the libLLVM dylib instead; built in CI
-          # so the llvm_static=false configuration doesn't bitrot.
-          nixd-llvm-dynamic = nixd.override { llvmStatic = false; };
+          nixd-llvm-static = nixd.override { llvmStatic = true; };
           nixdMono = callPackage ./. { inherit nixComponents llvmPackages; };
           nixdLLVM = nixdMono.override { stdenv = if stdenv.isDarwin then stdenv else llvmPackages.stdenv; };
           regressionDeps = with pkgs; [
@@ -74,7 +72,7 @@
           packages = {
             inherit
               nixd
-              nixd-llvm-dynamic
+              nixd-llvm-static
               nixf
               nixt
               ;

--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,7 @@ endif
 gtest = dependency('gtest')
 gtest_main = dependency('gtest_main')
 
-llvm = dependency('llvm')
+llvm = dependency('llvm', modules: ['support'], static: get_option('llvm_static'))
 boost = dependency('boost')
 nlohmann_json = dependency('nlohmann_json')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+  'llvm_static',
+  type: 'boolean',
+  value: false,
+  description: 'Link LLVM statically (only the "support" component is used). Requires LLVM static archives to be installed. Greatly reduces the runtime closure since the monolithic libLLVM dylib is not needed.',
+)

--- a/nixd/default.nix
+++ b/nixd/default.nix
@@ -12,6 +12,7 @@
   boost,
   libxml2,
   zlib,
+  llvmStatic ? true,
 }:
 
 let
@@ -33,7 +34,11 @@ stdenv.mkDerivation {
   # Link only LLVM's "support" component statically instead of the
   # monolithic libLLVM dylib; this keeps ~550 MiB of LLVM out of the
   # runtime closure. Static LLVMSupport needs zlib/libxml2 at link time.
-  mesonFlags = [ (lib.mesonBool "llvm_static" true) ];
+  mesonFlags = [ (lib.mesonBool "llvm_static" llvmStatic) ];
+
+  # Fail the build if the libLLVM dylib ever sneaks back into the closure,
+  # e.g. because the static link above silently fell back to dynamic.
+  disallowedRequisites = lib.optionals llvmStatic [ (lib.getLib llvmPackages.llvm) ];
 
   preConfigure = ''
     cd ${pname}

--- a/nixd/default.nix
+++ b/nixd/default.nix
@@ -10,6 +10,8 @@
   llvmPackages,
   gtest,
   boost,
+  libxml2,
+  zlib,
 }:
 
 let
@@ -27,6 +29,11 @@ stdenv.mkDerivation {
   ];
 
   mesonBuildType = "release";
+
+  # Link only LLVM's "support" component statically instead of the
+  # monolithic libLLVM dylib; this keeps ~550 MiB of LLVM out of the
+  # runtime closure. Static LLVMSupport needs zlib/libxml2 at link time.
+  mesonFlags = [ (lib.mesonBool "llvm_static" true) ];
 
   preConfigure = ''
     cd ${pname}
@@ -47,6 +54,8 @@ stdenv.mkDerivation {
     llvmPackages.llvm
     gtest
     boost
+    libxml2
+    zlib
   ];
 
   meta = {

--- a/nixd/default.nix
+++ b/nixd/default.nix
@@ -12,7 +12,7 @@
   boost,
   libxml2,
   zlib,
-  llvmStatic ? true,
+  llvmStatic ? false,
 }:
 
 let

--- a/nixd/meson.build
+++ b/nixd/meson.build
@@ -31,7 +31,7 @@ gtest = dependency('gtest')
 gtest_main = dependency('gtest_main')
 nixf = dependency('nixf')
 nixt = dependency('nixt')
-llvm = dependency('llvm')
+llvm = dependency('llvm', modules: ['support'], static: get_option('llvm_static'))
 
 pkgconfig = import('pkgconfig')
 

--- a/nixd/meson_options.txt
+++ b/nixd/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+  'llvm_static',
+  type: 'boolean',
+  value: false,
+  description: 'Link LLVM statically (only the "support" component is used). Requires LLVM static archives to be installed. Greatly reduces the runtime closure since the monolithic libLLVM dylib is not needed.',
+)


### PR DESCRIPTION
nixd only uses LLVM's Support/ADT utilities (StringRef, JSON, Error, CommandLine, ...), yet linking against the monolithic libLLVM dylib pulls the entire LLVM lib output (~550 MiB) into the runtime closure.

Add an llvm_static meson option (default: false, no behavior change) that links just the static "support" component instead. Enable it in the Nix package, where the static archives are always available; this requires zlib and libxml2 at link time, which libLLVM previously resolved internally.

Shrinks the nixd runtime closure from 702 MiB to 158 MiB.

see https://github.com/nix-community/nixd/issues/317