### PR TITLE
fix(completion): retrigger incomplete results

### DIFF
--- a/nixd/lib/Controller/Completion.cpp
+++ b/nixd/lib/Controller/Completion.cpp
@@ -465,9 +465,10 @@ void Controller::onCompletion(const CompletionParams &Params,
                               Callback<CompletionList> Reply) {
   using CheckTy = CompletionList;
   auto Action = [Reply = std::move(Reply), URI = Params.textDocument.uri,
-                 Pos = toNixfPosition(Params.position), this]() mutable {
+                 Pos = toNixfPosition(Params.position),
+                 Context = Params.context, this]() mutable {
     const auto File = URI.file().str();
-    return Reply([&]() -> llvm::Expected<CompletionList> {
+    auto Result = [&]() -> llvm::Expected<CompletionList> {
       const auto TU = CheckDefault(getTU(File));
       const auto AST = CheckDefault(getAST(*TU));
 
@@ -484,42 +485,50 @@ void Controller::onCompletion(const CompletionParams &Params,
         EditRange.start = EditRange.end;
       }
 
-      return [&]() {
-        CompletionList List;
-        const VariableLookupAnalysis &VLA = *TU->variableLookup();
-        try {
-          switch (UpExpr.kind()) {
-          // In these cases, assume the cursor have "variable" scoping.
-          case Node::NK_ExprVar: {
-            completeVarName(EditRange, VLA, PM,
-                            static_cast<const nixf::ExprVar &>(UpExpr),
-                            *nixpkgsClient(), List.items);
-            return List;
-          }
-          // A "select" expression. e.g.
-          // foo.a|
-          // foo.|
-          // foo.a.bar|
-          case Node::NK_ExprSelect: {
-            const auto &Select = static_cast<const nixf::ExprSelect &>(UpExpr);
-            completeSelect(EditRange, Select, *nixpkgsClient(), VLA, PM,
-                           N.kind() == Node::NK_Dot, List.items);
-            return List;
-          }
-          case Node::NK_ExprAttrs: {
-            completeAttrPath(EditRange, N, PM, OptionsLock, Options,
-                             ClientCaps.CompletionSnippets, List.items);
-            return List;
-          }
-          default:
-            return List;
-          }
-        } catch (ExceedSizeError &Err) {
-          List.isIncomplete = true;
+      CompletionList List;
+      const VariableLookupAnalysis &VLA = *TU->variableLookup();
+      try {
+        switch (UpExpr.kind()) {
+        // In these cases, assume the cursor have "variable" scoping.
+        case Node::NK_ExprVar: {
+          completeVarName(EditRange, VLA, PM,
+                          static_cast<const nixf::ExprVar &>(UpExpr),
+                          *nixpkgsClient(), List.items);
           return List;
         }
-      }();
-    }());
+        // A "select" expression. e.g.
+        // foo.a|
+        // foo.|
+        // foo.a.bar|
+        case Node::NK_ExprSelect: {
+          const auto &Select = static_cast<const nixf::ExprSelect &>(UpExpr);
+          completeSelect(EditRange, Select, *nixpkgsClient(), VLA, PM,
+                         N.kind() == Node::NK_Dot, List.items);
+          return List;
+        }
+        case Node::NK_ExprAttrs: {
+          completeAttrPath(EditRange, N, PM, OptionsLock, Options,
+                           ClientCaps.CompletionSnippets, List.items);
+          return List;
+        }
+        default:
+          return List;
+        }
+      } catch (ExceedSizeError &Err) {
+        List.isIncomplete = true;
+        return List;
+      }
+    }();
+
+    // The evaluator may return no names for an empty package prefix even
+    // though completing a subsequent prefix produces results. Tell clients to
+    // request completion again instead of caching the empty response from a
+    // dot-triggered request such as `pkgs.`.
+    if (Result &&
+        Context.triggerKind == CompletionTriggerKind::TriggerCharacter &&
+        Context.triggerCharacter == "." && Result->items.empty())
+      Result->isIncomplete = true;
+    return Reply(std::move(Result));
   };
   boost::asio::post(Pool, std::move(Action));
 }

--- a/nixd/lib/Eval/AttrSetProvider.cpp
+++ b/nixd/lib/Eval/AttrSetProvider.cpp
@@ -405,8 +405,9 @@ void AttrSetProvider::onOptionComplete(
           NewField.Description = std::move(Desc);
         }
         Response.emplace_back(std::move(NewField));
-        // We set this a very limited number as to speedup
-        if (Response.size() >= MaxItems)
+        // Keep one extra item as a truncation sentinel. The controller drops
+        // it at its matching limit and marks the LSP result as incomplete.
+        if (Response.size() > MaxItems)
           break;
       }
     }

--- a/nixd/tools/nixd/test/completion/options-incomplete.md
+++ b/nixd/tools/nixd/test/completion/options-incomplete.md
@@ -62,7 +62,7 @@
      CHECK: "id": 1,
 CHECK-NEXT:  "jsonrpc": "2.0",
 CHECK-NEXT:  "result": {
-CHECK-NEXT:    "isIncomplete": false,
+CHECK-NEXT:    "isIncomplete": true,
 ```
 
 

--- a/nixd/tools/nixd/test/completion/select-empty-prefix.md
+++ b/nixd/tools/nixd/test/completion/select-empty-prefix.md
@@ -1,0 +1,57 @@
+# RUN: nixd --nixpkgs-expr='{ python312 = 1; }' --lit-test < %s | FileCheck %s
+
+<-- initialize(0)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "method": "initialize",
+  "params": {
+    "processId": 123,
+    "rootPath": "",
+    "capabilities": {},
+    "trace": "off"
+  }
+}
+```
+
+<-- textDocument/didOpen
+
+```nix file:///completion.nix
+pkgs.
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "textDocument/completion",
+  "params": {
+    "textDocument": {
+      "uri": "file:///completion.nix"
+    },
+    "position": {
+      "line": 0,
+      "character": 5
+    },
+    "context": {
+      "triggerKind": 2,
+      "triggerCharacter": "."
+    }
+  }
+}
+```
+
+```
+     CHECK:      "id": 1,
+CHECK-NEXT:      "jsonrpc": "2.0",
+CHECK-NEXT:      "result": {
+CHECK-NEXT:        "isIncomplete": true,
+CHECK-NEXT:        "items": []
+CHECK-NEXT:      }
+```
+
+```json
+{"jsonrpc":"2.0","method":"exit"}
+```


### PR DESCRIPTION
## Summary

- mark empty completion responses triggered by `.` as incomplete
- mark evaluator-capped option responses as incomplete
- preserve the controller's `CheckDefault` and early-return patterns
- add/update LSP regressions for both incomplete-result paths

## Root cause

nixd advertises `.` as a completion trigger. For an incomplete selector such as `pkgs.`, parser recovery can reject the completion position and return an empty `CompletionList` with `isIncomplete: false`.

Option completion had a related pagination problem. The evaluator stopped after exactly 30 matching options, while the controller only recognized truncation when an additional item exceeded its matching 30-item limit. A capped response was therefore reported with `isIncomplete: false` even though narrower prefixes could produce candidates outside the first page.

Clients such as blink.cmp cache complete responses. They consequently kept filtering the empty or truncated result as the user typed instead of sending a prefix-specific request.

## Fix

After the controller has produced a response, an empty dot-triggered result is marked incomplete. This covers parser-recovery early exits without replacing the existing `CheckDefault` idiom or changing the switch's early-return structure.

The option evaluator now returns one item beyond its limit as a truncation sentinel, matching package completion. The controller drops that extra item at its own limit and sets `isIncomplete: true`, prompting `TriggerForIncompleteCompletions` requests as the prefix grows.

Manual requests, non-empty dot results, and option sets that fit within the limit retain their existing completeness behavior.

## Validation

- Built with `nix develop -c meson compile -C build`
- Full Meson suite passes (6/6 targets, including the nixd LSP regressions)
- `clang-format --dry-run --Werror` passes
- `git diff --check` passes
- Raw Neovim LSP probe against the packaged binary confirms a capped 30-item option response is now incomplete and a subsequent prefix retrigger reaches nixd
- Verified interactively with Neovim and blink.cmp that `pkgs.pyt` includes `python312`
