### PR TITLE
vim inlay hint

### DIFF
--- a/nixd/lib/Controller/InlayHints.cpp
+++ b/nixd/lib/Controller/InlayHints.cpp
@@ -56,6 +56,32 @@ class NixpkgsInlayHintsProvider {
 
   llvm::StringRef Src;
 
+  void addHint(const Node &N, Selector Selector) {
+    if (!rangeOK(N.positionRange()))
+      return;
+
+    // Ask nixpkgs eval to provide its information. This is relatively slow.
+    // Maybe better query a set of packages in the future?
+    std::binary_semaphore Ready(0);
+    AttrPathInfoResponse R;
+    auto OnReply = [&Ready, &R](llvm::Expected<AttrPathInfoResponse> Resp) {
+      if (Resp)
+        R = *Resp;
+      Ready.release();
+    };
+    NixpkgsProvider.attrpathInfo(Selector, std::move(OnReply));
+    Ready.acquire();
+
+    if (const std::optional<std::string> &Version = R.PackageDesc.Version) {
+      Hints.emplace_back(InlayHint{
+          .position = toLSPPosition(Src, N.rCur()),
+          .label = ": " + *Version,
+          .kind = InlayHintKind::Designator,
+          .range = toLSPRange(Src, N.range()),
+      });
+    }
+  }
+
 public:
   NixpkgsInlayHintsProvider(AttrSetClient &NixpkgsProvider,
                             const VariableLookupAnalysis &VLA,
@@ -72,39 +98,15 @@ public:
     if (!N)
       return;
     if (N->kind() == Node::NK_ExprVar) {
-      if (havePackageScope(*N, VLA, PMA)) {
-        if (!rangeOK(N->positionRange()))
-          return;
-        // Ask nixpkgs eval to provide it's information.
-        // This is relatively slow. Maybe better query a set of packages in the
-        // future?
-        std::binary_semaphore Ready(0);
-        const std::string &Name = static_cast<const ExprVar &>(*N).id().name();
-        AttrPathInfoResponse R;
-        auto OnReply = [&Ready, &R](llvm::Expected<AttrPathInfoResponse> Resp) {
-          if (!Resp) {
-            Ready.release();
-            return;
-          }
-          R = *Resp;
-          Ready.release();
-        };
-        NixpkgsProvider.attrpathInfo({Name}, std::move(OnReply));
-        Ready.acquire();
-
-        if (const std::optional<std::string> &Version = R.PackageDesc.Version) {
-          // Construct inlay hints.
-          InlayHint H{
-              .position = toLSPPosition(Src, N->rCur()),
-              .label = ": " + *Version,
-              .kind = InlayHintKind::Designator,
-              .range = toLSPRange(Src, N->range()),
-          };
-          Hints.emplace_back(std::move(H));
-        }
-      }
+      addHint(*N, idioms::mkVarSelector(static_cast<const ExprVar &>(*N), VLA,
+                                        PMA));
+    } else if (N->kind() == Node::NK_ExprSelect) {
+      addHint(*N, idioms::mkSelector(static_cast<const ExprSelect &>(*N), VLA,
+                                     PMA));
+      // The complete selection has been queried; do not also query its base.
+      return;
     }
-    // FIXME: process other node kinds. e.g. ExprSelect.
+
     for (const Node *Ch : N->children())
       dfs(Ch);
   }

--- a/nixd/tools/nixd/test/inlay-hint.md
+++ b/nixd/tools/nixd/test/inlay-hint.md
@@ -1,5 +1,5 @@
 # RUN: nixd --lit-test \
-# RUN: --nixpkgs-expr="{ hello.version = \"0.3.12\";  }" \
+# RUN: --nixpkgs-expr="{ hello.version = \"0.3.12\"; vimPlugins.nvim-lspconfig.version = \"2.5.0\"; vimPlugins.blink-cmp.version = \"1.7.0\"; }" \
 # RUN: < %s | FileCheck %s
 
 <-- initialize(0)
@@ -20,7 +20,11 @@
 ```
 
 ```nix file:///basic.nix
-with pkgs; [ hello  ]
+[
+  (with pkgs; [ hello ])
+  pkgs.vimPlugins.nvim-lspconfig
+  (with pkgs.vimPlugins; [ blink-cmp ])
+]
 ```
 
 
@@ -40,8 +44,8 @@ with pkgs; [ hello  ]
             "character":0
           },
           "end":{
-            "line":0,
-            "character":20
+            "line":4,
+            "character":1
           }
         }
     }
@@ -57,8 +61,26 @@ CHECK-NEXT:      "label": ": 0.3.12",
 CHECK-NEXT:      "paddingLeft": false,
 CHECK-NEXT:      "paddingRight": false,
 CHECK-NEXT:      "position": {
-CHECK-NEXT:        "character": 18,
-CHECK-NEXT:        "line": 0
+CHECK-NEXT:        "character": 21,
+CHECK-NEXT:        "line": 1
+CHECK-NEXT:      }
+CHECK-NEXT:    },
+CHECK-NEXT:    {
+CHECK-NEXT:      "label": ": 2.5.0",
+CHECK-NEXT:      "paddingLeft": false,
+CHECK-NEXT:      "paddingRight": false,
+CHECK-NEXT:      "position": {
+CHECK-NEXT:        "character": 32,
+CHECK-NEXT:        "line": 2
+CHECK-NEXT:      }
+CHECK-NEXT:    },
+CHECK-NEXT:    {
+CHECK-NEXT:      "label": ": 1.7.0",
+CHECK-NEXT:      "paddingLeft": false,
+CHECK-NEXT:      "paddingRight": false,
+CHECK-NEXT:      "position": {
+CHECK-NEXT:        "character": 36,
+CHECK-NEXT:        "line": 3
 CHECK-NEXT:      }
 CHECK-NEXT:    }
 ```


### PR DESCRIPTION
I wanted to display the versions of my vim plugins like so:

<img width="1077" height="604" alt="image" src="https://github.com/user-attachments/assets/0491d2b6-82f5-484e-bfd5-ed427b7f56f4" />

Note: This PR is entirely AI generated but I made this for myself mostly so I’m okay if you reject this

One possible issue is that `mkSelector` can throw, and I don't catch it. But is there something that may catch it up the stack? 

Ideally rather than throwing it should be wrapped in something like std::optional or std::expected, but I'm still new to the repo and I don't really what's one docket for the future.

But yeah generally doing this would lower the amount of crashes I think.

Also I just **_really_** don't like using exceptions.